### PR TITLE
docs: enhance README with getting started guide and comprehensive documentation

### DIFF
--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -10,7 +10,8 @@ gqlkit is a convention-driven code generator for GraphQL servers in TypeScript. 
 - **Fail-fast validation**: Actionable errors for type mismatches, missing references, and convention violations
 - **Documentation extraction**: TSDoc comments automatically become GraphQL schema descriptions with `@deprecated` support
 - **Branded scalar types**: Type-safe distinction between GraphQL scalar types (ID, Int, Float) via branded TypeScript types from `@gqlkit-ts/runtime`
-- **Custom scalar configuration**: User-defined scalar type mappings via `gqlkit.config.ts` with `defineConfig()`
+- **Custom scalar definition**: `DefineScalar<Name, Base>` utility type for inline custom scalar types with embedded metadata, or config-based mappings via `gqlkit.config.ts`
+- **Comprehensive type support**: Enum, Union, Input Object, and `@oneOf` input object types from TypeScript conventions
 - **Multiple output formats**: Generate schema AST (DocumentNode) or SDL string, with optional schema pruning
 
 ## Target Use Cases
@@ -26,4 +27,4 @@ gqlkit provides a "kit" experience: consistent conventions paired with consisten
 
 ---
 _Focus on patterns and purpose, not exhaustive feature lists_
-_Updated: 2026-01-02 - Custom scalar configuration and SDL output capabilities_
+_Updated: 2026-01-05 - DefineScalar utility type and comprehensive type support_

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -39,12 +39,13 @@ Minimal runtime utilities for user codebases:
 - `createGqlkitApis<TContext>()` factory function
 - Type definitions for resolvers (`QueryResolver`, `MutationResolver`, `FieldResolver`)
 - Branded scalar types (`IDString`, `IDNumber`, `Int`, `Float`) for explicit GraphQL scalar mapping
+- `DefineScalar<Name, Base, Only?>` utility type for custom scalar definitions
 - `NoArgs` helper type
 
 ### User Convention Directories (gqlkit-managed)
-**Types**: `src/gql/types/` - User-defined GraphQL types
-**Resolvers**: `src/gql/resolvers/` - Resolver implementations
-**Output**: `src/gqlkit/generated/` - Generated schema.ts and resolvers.ts
+**Types**: `src/gqlkit/types/` - User-defined GraphQL types
+**Resolvers**: `src/gqlkit/resolvers/` - Resolver implementations
+**Output**: `src/gqlkit/__generated__/` - Generated typeDefs.ts, resolvers.ts, schema.graphql
 
 ## Naming Conventions
 
@@ -76,4 +77,4 @@ import { extractTypes } from "../type-extractor/index.js";
 
 ---
 _Document patterns, not file trees. New files following patterns shouldn't require updates_
-_Updated: 2026-01-03 - Golden file testing pattern (replaced e2e/ pattern)_
+_Updated: 2026-01-05 - Updated convention directories from src/gql/ to src/gqlkit/_

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -64,8 +64,14 @@ Static code generation tool that analyzes TypeScript source files and produces G
 7. **TSDoc to GraphQL descriptions**: TSDoc comments are automatically extracted and converted to GraphQL schema descriptions, supporting `@deprecated` directives
 8. **Input Object convention**: Types with `*Input` suffix are recognized as GraphQL Input Object types for resolver arguments
 9. **Branded scalar types**: `@gqlkit-ts/runtime` provides `IDString`, `IDNumber`, `Int`, `Float` for explicit GraphQL scalar mapping. Plain `number` defaults to `Float`; use `Int` branded type for integer fields
-10. **Configuration file**: Optional `gqlkit.config.ts` with `defineConfig()` for custom scalar mappings and output options
+10. **DefineScalar utility type**: `DefineScalar<Name, Base, Only?>` from `@gqlkit-ts/runtime` for defining custom scalar types with embedded metadata. Supports input/output-only constraints
+11. **TypeScript type conversion patterns**:
+    - String enums become GraphQL enum types (enum value strings become GraphQL enum values)
+    - Union types of object types become GraphQL union types
+    - Types with `*Input` suffix become GraphQL input object types
+    - Union types with `*Input` suffix become `@oneOf` input objects
+12. **Configuration file**: Optional `gqlkit.config.ts` with `defineConfig()` for custom scalar mappings, output paths, and lifecycle hooks (e.g., `afterAllFileWrite`)
 
 ---
 _Document standards and patterns, not every dependency_
-_Updated: 2026-01-03 - Added knip for unused export detection_
+_Updated: 2026-01-05 - Added DefineScalar, type conversion patterns, and hooks configuration_

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ UPDATE_GOLDEN=true pnpm test
 pnpm test -- --coverage
 ```
 
-**Package manager**: pnpm (v10.26.1)
+**Package manager**: pnpm (v10.26.2)
 
 ## Project Architecture
 
@@ -42,13 +42,13 @@ pnpm test -- --coverage
 gqlkit relies on strict conventions to enable deterministic schema generation without configuration:
 
 1. **Source directories**:
-   - Types: `src/gql/types` - TypeScript type/interface exports
-   - Resolvers: `src/gql/resolvers` - Resolver signatures and implementations
+   - Types: `src/gqlkit/types/` - TypeScript type/interface exports
+   - Resolvers: `src/gqlkit/resolvers/` - Resolver signatures and implementations
 
 2. **Type definitions**:
    - Plain TypeScript type exports (object/interface/union)
    - Field nullability and list-ness inferred from TypeScript types
-   - Only exports from `src/gql/types` are considered
+   - Only exports from `src/gqlkit/types/` are considered
 
 3. **Define API for resolvers** (using `@gqlkit-ts/runtime`):
    - `defineQuery<Args, Return>(resolver)` - Define Query field resolvers
@@ -71,21 +71,22 @@ examples/    - Example projects demonstrating usage
 ```
 
 **CLI Pipeline** (`packages/cli/src/`):
-- `type-extractor/` - Scans TypeScript types from `src/gql/types`
-- `resolver-extractor/` - Scans resolver definitions from `src/gql/resolvers`
+- `type-extractor/` - Scans TypeScript types from `src/gqlkit/types/`
+- `resolver-extractor/` - Scans resolver definitions from `src/gqlkit/resolvers/`
 - `schema-generator/` - Builds GraphQL AST and resolver maps
 - `gen-orchestrator/` - Coordinates pipeline stages, handles diagnostics
+- `shared/` - Shared utilities across pipeline stages
 
 ### Code Generation Flow
 
 `gqlkit gen`:
-1. Scans `src/gql/types` and `src/gql/resolvers`
+1. Scans `src/gqlkit/types/` and `src/gqlkit/resolvers/`
 2. Builds internal type graph from TypeScript types
 3. Validates resolver signatures (parent/return types exist, resolver groups match)
 4. Generates:
    - `typeDefs`: GraphQL schema AST (DocumentNode) representing type definitions
    - `resolvers`: Resolver map object aggregating all resolver implementations
-5. Outputs to `src/gqlkit/generated/**` (schema.ts, resolvers.ts)
+5. Outputs to `src/gqlkit/__generated__/` (schema.ts, resolvers.ts)
 
 ### Design Principles
 
@@ -130,8 +131,13 @@ This project follows Kiro-style Spec-Driven Development.
 
 Uses **golden file testing** for CLI validation:
 - Test cases in `packages/cli/src/gen-orchestrator/testdata/`
-- Each case: `types/`, `resolvers/`, `expected/` directories
+- Each case has an `expected/` directory with snapshot files
 - Tests compare generated output against `expected/` snapshots
+
+### Testing Guidelines
+
+- **Prefer golden file tests over unit tests**: For code analysis, schema generation, and code generation logic, avoid function-level unit tests. Instead, add test cases to `testdata/` to verify correct behavior and increase coverage.
+- **Keep testdata MECE**: Ensure test cases are Mutually Exclusive and Collectively Exhaustive—each case should cover a distinct scenario without overlap, and together they should cover all important behaviors.
 
 ## Coding Conventions
 


### PR DESCRIPTION
## Summary

- Add step-by-step getting started guide with Task example for quick onboarding
- Document all features: custom scalars (DefineScalar), TSDoc/JSDoc, enums, unions, input objects, @oneOf
- Update source directory paths from `src/gql/` to `src/gqlkit/`
- Add configuration examples for scalars, output paths, and hooks
- Update steering documents and CLAUDE.md to reflect current state

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Check code examples are syntactically correct
- [ ] Confirm links and formatting work properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)