### PR TITLE
docs: prioritize string literal unions over TypeScript enums for enum types

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,16 +314,20 @@ enum UserStatus {
 
 ### Enum types
 
-TypeScript string enums are converted to GraphQL enum types:
+String literal unions are converted to GraphQL enum types:
 
 ```ts
 /**
  * User account status
  */
+export type UserStatus = "ACTIVE" | "INACTIVE";
+```
+
+TypeScript string enums are also supported:
+
+```ts
 export enum UserStatus {
-  /** User is active */
   Active = "ACTIVE",
-  /** User is inactive */
   Inactive = "INACTIVE",
 }
 ```


### PR DESCRIPTION
## Summary

- Update the Enum types section in README to present string literal unions as the primary approach
- Keep TypeScript enums as a secondary alternative with "also supported" phrasing
- Maintain TypeScript enum example in `@deprecated` section (required for per-value deprecation)

## Test plan

- [x] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)