### PR TITLE
refactor(runtime): replace branded types with optional property pattern for resolvers

### DIFF
--- a/packages/cli/src/shared/metadata-detector.ts
+++ b/packages/cli/src/shared/metadata-detector.ts
@@ -60,7 +60,14 @@ function createDefaultResult(): ScalarMetadataResult {
   };
 }
 
-function getActualMetadataType(metadataType: ts.Type): ts.Type | null {
+/**
+ * Extracts the actual type from an optional property type (T | undefined).
+ * Used by both scalar and resolver metadata detection.
+ *
+ * @param metadataType - The type of the metadata property (may be union with undefined)
+ * @returns The actual type excluding undefined, or null if extraction fails
+ */
+export function getActualMetadataType(metadataType: ts.Type): ts.Type | null {
   if (metadataType.isUnion()) {
     const nonUndefinedTypes = metadataType.types.filter(
       (t) => !(t.flags & ts.TypeFlags.Undefined),

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -123,26 +123,25 @@ export type FieldResolverFn<TParent, TArgs, TResult, TContext = unknown> = (
 ) => TResult | Promise<TResult>;
 
 /**
- * Type-level symbol for identifying resolvers.
- * This symbol only exists at the type level and has no runtime representation.
- * Used by CLI to detect resolvers through type analysis.
- */
-declare const ResolverBrandSymbol: unique symbol;
-
-/**
- * The type of the resolver brand symbol.
- * Export this type so users can access brand information from resolver types.
- */
-export type ResolverBrand = typeof ResolverBrandSymbol;
-
-/**
  * The kind of resolver.
  */
 export type ResolverKind = "query" | "mutation" | "field";
 
 /**
- * Branded Query resolver type.
- * Includes type-level metadata for CLI detection.
+ * Resolver metadata structure embedded in intersection types.
+ * Used by CLI to detect and identify resolver types through type analysis.
+ */
+export interface ResolverMetadataShape {
+  readonly kind: ResolverKind;
+  readonly args: unknown;
+  readonly result: unknown;
+  readonly parent?: unknown;
+}
+
+/**
+ * Query resolver type with metadata.
+ * The metadata is embedded as an optional property with space-prefixed key
+ * to avoid collision with user-defined properties.
  * @typeParam TArgs - The type of arguments the resolver accepts
  * @typeParam TResult - The return type of the resolver
  * @typeParam TContext - The context type (defaults to unknown)
@@ -152,7 +151,7 @@ export type QueryResolver<TArgs, TResult, TContext = unknown> = QueryResolverFn<
   TResult,
   TContext
 > & {
-  [ResolverBrandSymbol]: {
+  " $gqlkitResolver"?: {
     kind: "query";
     args: TArgs;
     result: TResult;
@@ -160,8 +159,9 @@ export type QueryResolver<TArgs, TResult, TContext = unknown> = QueryResolverFn<
 };
 
 /**
- * Branded Mutation resolver type.
- * Includes type-level metadata for CLI detection.
+ * Mutation resolver type with metadata.
+ * The metadata is embedded as an optional property with space-prefixed key
+ * to avoid collision with user-defined properties.
  * @typeParam TArgs - The type of arguments the resolver accepts
  * @typeParam TResult - The return type of the resolver
  * @typeParam TContext - The context type (defaults to unknown)
@@ -171,7 +171,7 @@ export type MutationResolver<
   TResult,
   TContext = unknown,
 > = MutationResolverFn<TArgs, TResult, TContext> & {
-  [ResolverBrandSymbol]: {
+  " $gqlkitResolver"?: {
     kind: "mutation";
     args: TArgs;
     result: TResult;
@@ -179,8 +179,9 @@ export type MutationResolver<
 };
 
 /**
- * Branded Field resolver type.
- * Includes type-level metadata for CLI detection.
+ * Field resolver type with metadata.
+ * The metadata is embedded as an optional property with space-prefixed key
+ * to avoid collision with user-defined properties.
  * @typeParam TParent - The parent type this field belongs to
  * @typeParam TArgs - The type of arguments the resolver accepts
  * @typeParam TResult - The return type of the resolver
@@ -192,7 +193,7 @@ export type FieldResolver<
   TResult,
   TContext = unknown,
 > = FieldResolverFn<TParent, TArgs, TResult, TContext> & {
-  [ResolverBrandSymbol]: {
+  " $gqlkitResolver"?: {
     kind: "field";
     parent: TParent;
     args: TArgs;


### PR DESCRIPTION
## Summary

- Replace unique symbol-based branding pattern with space-prefixed optional property pattern (`" $gqlkitResolver"`) for resolver type metadata
- Add `ResolverMetadataShape` interface for resolver metadata structure
- Update CLI detection logic to use `getProperty()` instead of symbol lookup
- Export `getActualMetadataType` utility for optional property type extraction
- Remove `ResolverBrandSymbol` and `ResolverBrand` exports

## Motivation

The optional property pattern provides better error messages when type mismatches occur. When users see type errors, they now see readable property names like `" $gqlkitResolver"` instead of obscure symbol references.

## Test plan

- [x] All 164 existing tests pass
- [x] Golden file tests (18 cases) verify schema generation unchanged
- [x] TypeScript type checking passes
- [x] Examples compile without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)