### PR TITLE
chore(deps): reorganize dependencies across packages

### DIFF
--- a/examples/full-featured/package.json
+++ b/examples/full-featured/package.json
@@ -8,14 +8,13 @@
     "dev": "pnpm gen && pnpm start"
   },
   "dependencies": {
-    "@gqlkit-ts/cli": "workspace:*",
     "@gqlkit-ts/runtime": "workspace:*",
     "@graphql-tools/schema": "^10.0.0",
     "graphql": "^16.12.0",
     "graphql-yoga": "^5.0.0"
   },
   "devDependencies": {
-    "tsx": "^4.21.0",
+    "@gqlkit-ts/cli": "workspace:*",
     "typescript": "^5.9.0"
   }
 }

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -8,14 +8,13 @@
     "dev": "pnpm gen && pnpm start"
   },
   "dependencies": {
-    "@gqlkit-ts/cli": "workspace:*",
     "@gqlkit-ts/runtime": "workspace:*",
     "@graphql-tools/schema": "^10.0.0",
     "graphql": "^16.12.0",
     "graphql-yoga": "^5.0.0"
   },
   "devDependencies": {
-    "tsx": "^4.21.0",
+    "@gqlkit-ts/cli": "workspace:*",
     "typescript": "^5.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "graphql": "^16.12.0",
     "knip": "^5.79.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^3.2.0"
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,16 +17,24 @@
   },
   "dependencies": {
     "@graphql-tools/utils": "^10.11.0",
-    "graphql": "^16.12.0",
     "gunshi": "^0.27.5",
     "jiti": "^2.4.2",
     "shell-quote": "^1.8.3"
   },
+  "peerDependencies": {
+    "graphql": "^16.12.0",
+    "typescript": "^5.9.3"
+  },
+  "peerDependenciesMeta": {
+    "graphql": {
+      "optional": true
+    },
+    "typescript": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@gqlkit-ts/runtime": "workspace:*",
-    "@types/node": "^22.19.3",
-    "@types/shell-quote": "^1.7.5",
-    "tsx": "^4.21.0",
-    "typescript": "5.9.3"
+    "@types/shell-quote": "^1.7.5"
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -22,14 +22,5 @@
     "build": "tsc --build",
     "test": "pnpm -w vitest run --project=runtime --typecheck",
     "typecheck": "tsc --noEmit"
-  },
-  "peerDependencies": {
-    "graphql": "^16.0.0"
-  },
-  "devDependencies": {
-    "@types/node": "^22.19.3",
-    "graphql": "^16.12.0",
-    "tsx": "^4.21.0",
-    "typescript": "5.9.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       knip:
         specifier: ^5.79.0
         version: 5.79.0(@types/node@22.19.3)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -32,9 +35,6 @@ importers:
 
   examples/full-featured:
     dependencies:
-      '@gqlkit-ts/cli':
-        specifier: workspace:*
-        version: link:../../packages/cli
       '@gqlkit-ts/runtime':
         specifier: workspace:*
         version: link:../../packages/runtime
@@ -48,18 +48,15 @@ importers:
         specifier: ^5.0.0
         version: 5.18.0(graphql@16.12.0)
     devDependencies:
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
+      '@gqlkit-ts/cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
       typescript:
         specifier: ^5.9.0
         version: 5.9.3
 
   examples/minimal:
     dependencies:
-      '@gqlkit-ts/cli':
-        specifier: workspace:*
-        version: link:../../packages/cli
       '@gqlkit-ts/runtime':
         specifier: workspace:*
         version: link:../../packages/runtime
@@ -73,9 +70,9 @@ importers:
         specifier: ^5.0.0
         version: 5.18.0(graphql@16.12.0)
     devDependencies:
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
+      '@gqlkit-ts/cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
       typescript:
         specifier: ^5.9.0
         version: 5.9.3
@@ -97,37 +94,18 @@ importers:
       shell-quote:
         specifier: ^1.8.3
         version: 1.8.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
     devDependencies:
       '@gqlkit-ts/runtime':
         specifier: workspace:*
         version: link:../runtime
-      '@types/node':
-        specifier: ^22.19.3
-        version: 22.19.3
       '@types/shell-quote':
         specifier: ^1.7.5
         version: 1.7.5
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
 
-  packages/runtime:
-    devDependencies:
-      '@types/node':
-        specifier: ^22.19.3
-        version: 22.19.3
-      graphql:
-        specifier: ^16.12.0
-        version: 16.12.0
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
-      typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+  packages/runtime: {}
 
 packages:
 


### PR DESCRIPTION
## Summary

- Move `@gqlkit-ts/cli` from dependencies to devDependencies in examples (CLI is only needed at build time)
- Hoist `tsx` to root devDependencies for shared usage across packages
- Convert `graphql` and `typescript` to optional peerDependencies in cli package
- Remove redundant devDependencies from runtime package (now managed at root level)

## Test plan

- [ ] Verify `pnpm install` works correctly
- [ ] Verify `pnpm build` succeeds
- [ ] Verify `pnpm test` passes
- [ ] Verify examples still work with `pnpm dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)