### PR TITLE
feat(docs): add Algolia DocSearch integration

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,10 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build docs
         run: pnpm --filter @gqlkit-ts/docs build
+        env:
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+          ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:

--- a/packages/docs/docs/.vitepress/config.ts
+++ b/packages/docs/docs/.vitepress/config.ts
@@ -14,6 +14,20 @@ export default defineConfig({
   },
 
   themeConfig: {
+    search:
+      process.env.ALGOLIA_APP_ID &&
+      process.env.ALGOLIA_API_KEY &&
+      process.env.ALGOLIA_INDEX_NAME
+        ? {
+            provider: "algolia",
+            options: {
+              appId: process.env.ALGOLIA_APP_ID,
+              apiKey: process.env.ALGOLIA_API_KEY,
+              indexName: process.env.ALGOLIA_INDEX_NAME,
+            },
+          }
+        : undefined,
+
     nav: [{ text: "Guide", link: "/guide/getting-started" }],
 
     sidebar: {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -9,6 +9,7 @@
     "preview": "vitepress preview docs"
   },
   "devDependencies": {
+    "@types/node": "24.10.4",
     "vitepress": "1.6.4",
     "vue": "3.5.26"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
         specifier: ^0.1.2
         version: 0.1.2(typescript@5.9.3)
     devDependencies:
+      '@types/node':
+        specifier: 24.10.4
+        version: 24.10.4
       vitepress:
         specifier: 1.6.4
         version: 1.6.4(@algolia/client-search@5.46.2)(@types/node@24.10.4)(postcss@8.5.6)(search-insights@2.17.3)(typescript@5.9.3)


### PR DESCRIPTION
## Summary
- Add Algolia DocSearch configuration to VitePress documentation site
- Configure GitHub Actions to pass Algolia credentials via environment variables
- Add `@types/node` for TypeScript compatibility

## Setup Required
Add the following secrets in repository settings (Settings → Secrets and variables → Actions):

| Secret | Description |
|--------|-------------|
| `ALGOLIA_APP_ID` | Algolia application ID |
| `ALGOLIA_API_KEY` | Search-only API key |
| `ALGOLIA_INDEX_NAME` | DocSearch index name |

## Test plan
- [ ] Add GitHub Secrets with Algolia credentials
- [ ] Trigger docs deployment workflow
- [ ] Verify search functionality on deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)