### PR TITLE
feat(docs): add sitemap generation and improve SEO configuration

### DIFF
--- a/packages/docs/docs/.vitepress/config.ts
+++ b/packages/docs/docs/.vitepress/config.ts
@@ -103,12 +103,14 @@ export default defineConfig({
     ],
 
     editLink: {
-      pattern: "https://github.com/izumin5210/gqlkit/edit/main/packages/docs/docs/:path",
+      pattern:
+        "https://github.com/izumin5210/gqlkit/edit/main/packages/docs/docs/:path",
       text: "Edit this page on GitHub",
     },
 
     footer: {
-      message: 'Released under the <a href="https://github.com/izumin5210/gqlkit/blob/main/LICENSE">MIT License</a>.',
+      message:
+        'Released under the <a href="https://github.com/izumin5210/gqlkit/blob/main/LICENSE">MIT License</a>.',
       copyright: "Copyright © 2025-present izumin5210",
     },
 


### PR DESCRIPTION
## Summary

- Add sitemap generation with hostname (`https://gqlkit.izumin.dev`) for search engine indexing
- Enable `lastUpdated` to show page modification dates from git history
- Add `editLink` for "Edit this page on GitHub" functionality
- Add footer with MIT License and copyright information
- Enable `externalLinkIcon` for better UX on external links

## Test plan

- [ ] Verify `pnpm --filter @gqlkit-ts/docs build` succeeds and generates `sitemap.xml`
- [ ] Check that the documentation site displays the last updated date on pages
- [ ] Confirm the "Edit this page on GitHub" link appears and points to the correct file
- [ ] Verify the footer displays license and copyright information
- [ ] Check that external links show the external link icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)