### PR TITLE
docs(steering): sync steering files with codebase

### DIFF
--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -13,6 +13,7 @@ gqlkit is a convention-driven code generator for GraphQL servers in TypeScript. 
 - **Custom scalar definition**: `GqlScalar<Name, Base>` utility type for inline custom scalar types with embedded metadata, or config-based mappings via `gqlkit.config.ts`
 - **Comprehensive type support**: Enum, Union, Input Object, Interface, and `@oneOf` input object types from TypeScript conventions
 - **Interface type definition**: `GqlInterface` utility type for GraphQL interfaces with inheritance support via `implements`
+- **Abstract type resolution**: `defineResolveType` and `defineIsTypeOf` for runtime type resolution of unions and interfaces
 - **Default values**: Input field and argument default values via `GqlField<T, { defaultValue: ... }>`
 - **Auto-type generation**: Inline object types in fields and resolver arguments are automatically converted to named GraphQL types with predictable naming conventions
 - **Multiple output formats**: Generate schema AST (DocumentNode) or SDL string, with optional schema pruning
@@ -30,4 +31,4 @@ gqlkit provides a "kit" experience: consistent conventions paired with consisten
 
 ---
 _Focus on patterns and purpose, not exhaustive feature lists_
-_Updated: 2026-01-09 - Added auto-type generation for inline object types_
+_Updated: 2026-01-14 - Added abstract type resolution capability_

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -10,6 +10,7 @@ Monorepo with feature-by-purpose organization. Each package has a clear responsi
 packages/
   cli/       - @gqlkit-ts/cli - Code generation CLI
   runtime/   - @gqlkit-ts/runtime - Define API and type utilities
+  docs/      - @gqlkit-ts/docs - Documentation site (Next.js + Nextra)
 examples/    - Example projects demonstrating usage
 ```
 
@@ -39,6 +40,7 @@ Pipeline-based architecture for code generation:
 Minimal runtime utilities for user codebases:
 - `createGqlkitApis<TContext>()` factory function
 - Type definitions for resolvers (`QueryResolver`, `MutationResolver`, `FieldResolver`)
+- Abstract type resolvers (`ResolveTypeResolver`, `IsTypeOfResolver`) for union/interface resolution
 - Branded scalar types (`IDString`, `IDNumber`, `Int`, `Float`) for explicit GraphQL scalar mapping
 - `GqlScalar<Name, Base, Only?>` utility type for custom scalar definitions
 - `GqlInterface<T, Meta?>` utility type for GraphQL interface definitions
@@ -46,6 +48,13 @@ Minimal runtime utilities for user codebases:
 - `GqlField<T, Meta>` for field-level metadata (directives, defaultValue)
 - `GqlDirective<Name, Args, Location>` utility type for custom directive definitions
 - `NoArgs` helper type
+
+### @gqlkit-ts/docs (`packages/docs/`)
+
+Documentation site built with Next.js and Nextra:
+- Internal package (not published)
+- Provides `bundle-docs` CLI for CLI package documentation bundling
+- Runs independently from main TypeScript project references
 
 ### User Convention Directories (gqlkit-managed)
 **Schema**: `src/gqlkit/schema/` - Types and resolvers co-located in the same files
@@ -81,4 +90,4 @@ import { extractTypes } from "../type-extractor/index.js";
 
 ---
 _Document patterns, not file trees. New files following patterns shouldn't require updates_
-_Updated: 2026-01-09 - Added auto-type-generator pipeline stage_
+_Updated: 2026-01-14 - Added docs package and abstract type resolvers_

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -60,7 +60,7 @@ Static code generation tool that analyzes TypeScript source files and produces G
 3. **gunshi for CLI**: Provides type-safe command definitions with built-in help generation
 4. **No decorators**: Design decision to keep schema generation based purely on type analysis
 5. **graphql-tools compatible output**: Generated resolvers work directly with `makeExecutableSchema`
-6. **Define API**: Factory-based resolver definition via `createGqlkitApis<TContext>()` from `@gqlkit-ts/runtime`, returning typed `defineQuery`, `defineMutation`, `defineField` functions with custom context support
+6. **Define API**: Factory-based resolver definition via `createGqlkitApis<TContext>()` from `@gqlkit-ts/runtime`, returning typed `defineQuery`, `defineMutation`, `defineField`, `defineResolveType`, and `defineIsTypeOf` functions with custom context support
 7. **TSDoc to GraphQL descriptions**: TSDoc comments are automatically extracted and converted to GraphQL schema descriptions, supporting `@deprecated` directives
 8. **Input Object convention**: Types with `*Input` suffix are recognized as GraphQL Input Object types for resolver arguments
 9. **Branded scalar types**: `@gqlkit-ts/runtime` provides `IDString`, `IDNumber`, `Int`, `Float` for explicit GraphQL scalar mapping. Plain `number` defaults to `Float`; use `Int` branded type for integer fields
@@ -73,9 +73,10 @@ Static code generation tool that analyzes TypeScript source files and produces G
     - `GqlInterface<T>` becomes GraphQL interface types
     - Inline object types become auto-generated named types with predictable naming conventions
 12. **Interface types**: `GqlInterface<T, { implements?: [...] }>` for GraphQL interfaces. `GqlObject<T, { implements: [...] }>` for object types implementing interfaces. Supports interface inheritance
-13. **Default values**: `GqlField<T, { defaultValue: literal }>` for input field defaults. Supports primitives, arrays, objects, and enum values. Requires TypeScript literal types (not `number` but `10`)
-14. **Configuration file**: Optional `gqlkit.config.ts` with `defineConfig()` for custom scalar mappings, output paths, and lifecycle hooks (e.g., `afterAllFileWrite`)
-15. **Auto-type generation naming conventions**: Predictable naming for inline object types:
+13. **Abstract type resolution**: `defineResolveType<TAbstract>` for union/interface `__resolveType`, `defineIsTypeOf<TObject>` for object `__isTypeOf`. Both integrate with resolver map generation
+14. **Default values**: `GqlField<T, { defaultValue: literal }>` for input field defaults. Supports primitives, arrays, objects, and enum values. Requires TypeScript literal types (not `number` but `10`)
+15. **Configuration file**: Optional `gqlkit.config.ts` with `defineConfig()` for custom scalar mappings, output paths, and lifecycle hooks (e.g., `afterAllFileWrite`)
+16. **Auto-type generation naming conventions**: Predictable naming for inline object types:
     - Object field: `{ParentTypeName}{PascalCaseFieldName}`
     - Input field: `{ParentTypeNameWithoutInputSuffix}{PascalCaseFieldName}Input`
     - Query/Mutation arg: `{PascalCaseFieldName}{PascalCaseArgName}Input`
@@ -83,4 +84,4 @@ Static code generation tool that analyzes TypeScript source files and produces G
 
 ---
 _Document standards and patterns, not every dependency_
-_Updated: 2026-01-09 - Added auto-type generation from inline object types_
+_Updated: 2026-01-14 - Added abstract type resolution (defineResolveType, defineIsTypeOf)_


### PR DESCRIPTION
## Summary

- Add `packages/docs/` (@gqlkit-ts/docs) documentation site to structure.md
- Add abstract type resolution capability (`defineResolveType`, `defineIsTypeOf`) to all steering files
- Update runtime package exports with `ResolveTypeResolver` and `IsTypeOfResolver` types

## Context

Steering files were out of sync with the current codebase. This PR updates them to reflect features added since the last steering update (2026-01-09).

## Test plan

- [x] Verified steering files accurately reflect current codebase structure
- [x] No code drift detected between steering and implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)