### PR TITLE
docs: simplify CLAUDE.md and sync steering files

### DIFF
--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -15,7 +15,7 @@ gqlkit is a convention-driven code generator for GraphQL servers in TypeScript. 
 - **Interface type definition**: `GqlInterface` utility type for GraphQL interfaces with inheritance support via `implements`
 - **Abstract type resolution**: `defineResolveType` and `defineIsTypeOf` for runtime type resolution of unions and interfaces
 - **Default values**: Input field and argument default values via `GqlField<T, { defaultValue: ... }>`
-- **Auto-type generation**: Inline object types in fields and resolver arguments are automatically converted to named GraphQL types with predictable naming conventions
+- **Auto-type generation**: Inline types (objects, unions, string literal unions) in fields and resolver arguments are automatically converted to named GraphQL types with predictable naming conventions
 - **Multiple output formats**: Generate schema AST (DocumentNode) or SDL string, with optional schema pruning
 
 ## Target Use Cases
@@ -31,4 +31,4 @@ gqlkit provides a "kit" experience: consistent conventions paired with consisten
 
 ---
 _Focus on patterns and purpose, not exhaustive feature lists_
-_Updated: 2026-01-14 - Added abstract type resolution capability_
+_Updated: 2026-01-21 - Expanded auto-type generation scope (unions, string literal unions)_

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -28,12 +28,12 @@ Pipeline-based architecture for code generation:
 - **Config Loading**: `src/config-loader/` - Configuration file loading and validation
 - **Type Extraction**: `src/type-extractor/` - Scans and analyzes TypeScript types
 - **Resolver Extraction**: `src/resolver-extractor/` - Scans and analyzes resolver definitions
-- **Auto-Type Generation**: `src/auto-type-generator/` - Generates named types from inline object definitions
+- **Auto-Type Generation**: `src/auto-type-generator/` - Generates named types from inline definitions (objects, unions, enums)
 - **Schema Generation**: `src/schema-generator/` - Builds GraphQL AST and resolver maps
 - **Orchestration**: `src/gen-orchestrator/` - Coordinates pipeline stages (reporter, writer)
 - **Shared Utilities**: `src/shared/` - Cross-cutting utilities used by multiple pipeline stages (e.g., TSDoc parsing, type conversion, TypeScript AST helpers)
 
-**Pattern**: Each pipeline stage has internal modules (scanner, extractor, collector, validator, etc.). Stages may use 2-phase processing where needed (e.g., type-extractor collects names first, then resolves types).
+**Pattern**: Each pipeline stage has internal modules (scanner, extractor, collector, validator, mapper, etc.). Stages may use 2-phase processing where needed (e.g., type-extractor collects names first, then resolves types with scalar base type mapping).
 
 ### @gqlkit-ts/runtime (`packages/runtime/`)
 
@@ -90,4 +90,4 @@ import { extractTypes } from "../type-extractor/index.js";
 
 ---
 _Document patterns, not file trees. New files following patterns shouldn't require updates_
-_Updated: 2026-01-18 - Clarified 2-phase processing pattern and shared utilities_
+_Updated: 2026-01-21 - Updated auto-type-generator scope (unions, enums), added mapper pattern_

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -72,20 +72,27 @@ Static code generation tool that analyzes TypeScript source files and produces G
     - Union types with `*Input` suffix become `@oneOf` input objects
     - `GqlInterface<T>` becomes GraphQL interface types
     - Inline object types become auto-generated named types with predictable naming conventions
+    - Inline union types in fields become auto-generated GraphQL Union or `@oneOf` Input Object types
+    - Inline string literal unions become auto-generated GraphQL enum types
 12. **Interface types**: `GqlInterface<T, { implements?: [...] }>` for GraphQL interfaces. `GqlObject<T, { implements: [...] }>` for object types implementing interfaces. Supports interface inheritance
 13. **Abstract type resolution**: `defineResolveType<TAbstract>` for union/interface `__resolveType`, `defineIsTypeOf<TObject>` for object `__isTypeOf`. Both integrate with resolver map generation
 14. **Default values**: `GqlField<T, { defaultValue: literal }>` for input field defaults. Supports primitives, arrays, objects, and enum values. Requires TypeScript literal types (not `number` but `10`)
 15. **Configuration file**: Optional `gqlkit.config.ts` with `defineConfig()` for custom scalar mappings, output paths, and lifecycle hooks (e.g., `afterAllFileWrite`)
-16. **Auto-type generation naming conventions**: Predictable naming for inline object types:
-    - Object field: `{ParentTypeName}{PascalCaseFieldName}`
-    - Input field: `{ParentTypeNameWithoutInputSuffix}{PascalCaseFieldName}Input`
-    - Query/Mutation arg: `{PascalCaseFieldName}{PascalCaseArgName}Input`
-    - Field resolver arg: `{ParentTypeName}{PascalCaseFieldName}{PascalCaseArgName}Input`
-17. **2-phase type extraction**: Separates type declaration context from field type context:
+16. **Auto-type generation naming conventions**: Predictable naming for inline types:
+    - Object field inline object: `{ParentTypeName}{PascalCaseFieldPath}`
+    - Input field inline object: `{ParentTypeNameWithoutInputSuffix}{PascalCaseFieldPath}Input`
+    - Query/Mutation arg inline object: `{PascalCaseFieldName}{PascalCaseArgName}Input`
+    - Field resolver arg inline object: `{ParentTypeName}{PascalCaseFieldName}{PascalCaseArgName}Input`
+    - Object field inline union: `{ParentTypeName}{PascalCaseFieldName}` (GraphQL Union)
+    - Input field inline union: `{ParentTypeName}{PascalCaseFieldName}Input` (GraphQL `@oneOf` Input Object)
+    - Inline string literal union: `{ParentTypeName}{PascalCaseFieldName}` (GraphQL Enum)
+17. **SCREAMING_SNAKE_CASE enum conversion**: Enum values are auto-converted to GraphQL-compliant SCREAMING_SNAKE_CASE format. Supports camelCase, PascalCase, snake_case, and kebab-case inputs. Resolver mappings are generated for value conversion between TypeScript and GraphQL representations
+18. **Automatic scalar base type mapping**: When `GqlScalar<Name, Base>` definitions are detected, all occurrences of the base type (e.g., `Date`) are automatically mapped to the corresponding scalar type (e.g., `DateTime`). Supports input-only and output-only constraints via the `only` parameter
+19. **2-phase type extraction**: Separates type declaration context from field type context:
     - Phase 1: Collect all exported type names (`knownTypeNames`)
     - Phase 2: Resolve field types using `knownTypeNames` to determine if references should be preserved or expanded
     - Key principle: In field context, only types in `knownTypeNames` are preserved as references; utility types (Omit, Pick, Simplify, etc.) are expanded to inline objects
 
 ---
 _Document standards and patterns, not every dependency_
-_Updated: 2026-01-18 - Added 2-phase type extraction pattern_
+_Updated: 2026-01-21 - Added inline union/enum auto-generation, SCREAMING_SNAKE_CASE conversion, automatic scalar mapping_

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,12 @@ gqlkit is a convention-driven code generator for GraphQL servers in TypeScript.
 
 **Core concept**: Define GraphQL types and resolver signatures in TypeScript → `gqlkit gen` generates GraphQL schema AST and a resolver map from your codebase.
 
+**For detailed information**:
+- Product vision and capabilities: `.kiro/steering/product.md`
+- Architecture and technical decisions: `.kiro/steering/tech.md`
+- Project structure and patterns: `.kiro/steering/structure.md`
+- User documentation: `packages/docs/src/content/`
+
 ## Common Commands
 
 ```bash
@@ -33,141 +39,7 @@ UPDATE_GOLDEN=true pnpm test
 pnpm test -- --coverage
 ```
 
-**Package manager**: pnpm (v10.26.2)
-
-## Project Architecture
-
-### Convention-Driven Design
-
-gqlkit relies on strict conventions to enable deterministic schema generation without configuration:
-
-1. **Source directory**: `src/gqlkit/schema/`
-   - Types and resolvers co-located in the same files
-   - Each file can contain type definitions and related resolvers together
-
-2. **Type definitions**:
-   - Plain TypeScript type exports (object/interface/union/enum)
-   - Field nullability and list-ness inferred from TypeScript types
-   - All exports from `src/gqlkit/schema/` are considered
-   - TSDoc/JSDoc comments become GraphQL descriptions (`@deprecated` supported)
-   - Utility types for advanced features:
-     - `GqlInterface<T, Meta?>` - GraphQL interface types
-     - `GqlObject<T, Meta>` - Type-level metadata (implements, directives)
-     - `GqlField<T, Meta>` - Field-level metadata (defaultValue, directives)
-     - `GqlDirective<Name, Args, Location>` - Custom directive definitions
-     - `GqlScalar<Name, Base, Only?>` - Custom scalar type definition
-
-3. **Define API for resolvers** (using `@gqlkit-ts/runtime`):
-   - `createGqlkitApis<TContext>()` factory returns typed resolver definition functions
-   - `defineQuery<Args, Return, Directives?>(resolver)` - Define Query field resolvers
-   - `defineMutation<Args, Return, Directives?>(resolver)` - Define Mutation field resolvers
-   - `defineField<Parent, Args, Return, Directives?>(resolver)` - Define type field resolvers
-   - Export name becomes the GraphQL field name
-   - Optional third type parameter for attaching directives to resolver fields
-
-4. **Resolver function signatures**:
-   - Query/Mutation: `(root, args, ctx, info) => Return`
-   - Field: `(parent, args, ctx, info) => Return`
-   - Use `NoArgs` type for fields without arguments
-
-### Monorepo Structure
-
-```
-packages/
-  cli/       - @gqlkit-ts/cli: Code generation CLI (gqlkit gen)
-  runtime/   - @gqlkit-ts/runtime: Define API, utility types, and branded scalars
-examples/    - Example projects demonstrating usage
-```
-
-**Runtime package exports** (`@gqlkit-ts/runtime`):
-- `createGqlkitApis<TContext>()` - Factory for resolver definition functions
-- Branded scalar types: `IDString`, `IDNumber`, `Int`, `Float`
-- `GqlScalar<Name, Base, Only?>` - Custom scalar type definition
-- `GqlInterface<T, Meta?>` - GraphQL interface type definition
-- `GqlObject<T, Meta>` - Type metadata (implements, directives)
-- `GqlField<T, Meta>` - Field metadata (defaultValue, directives)
-- `GqlDirective<Name, Args, Location>` - Custom directive definition
-- `NoArgs` - Helper type for fields without arguments
-
-**CLI Pipeline** (`packages/cli/src/`):
-- `commands/` - CLI command definitions using gunshi's `define()`
-- `config/` - Configuration type definitions and `defineConfig()` helper
-- `config-loader/` - Configuration file loading and validation
-- `type-extractor/` - Scans and analyzes TypeScript types from `src/gqlkit/schema/`
-  - `type-name-collector.ts` - Phase 1: Collects declared type names (including re-exports)
-  - `field-type-resolver.ts` - Phase 2: Resolves field types using knownTypeNames
-  - `type-extractor.ts` - Main type extraction logic
-- `resolver-extractor/` - Scans and analyzes resolver definitions from `src/gqlkit/schema/`
-- `auto-type-generator/` - Converts inline object types to named GraphQL types
-- `schema-generator/` - Builds GraphQL AST and resolver maps
-- `gen-orchestrator/` - Coordinates pipeline stages (reporter, writer)
-- `shared/` - Cross-cutting utilities (e.g., TSDoc parsing)
-
-### Code Generation Flow
-
-`gqlkit gen`:
-1. Scans `src/gqlkit/schema/`
-2. Builds internal type graph from TypeScript types
-3. Validates resolver signatures (parent/return types exist, resolver groups match)
-4. Generates:
-   - `typeDefs`: GraphQL schema AST (DocumentNode) representing type definitions
-   - `resolvers`: Resolver map object aggregating all resolver implementations
-5. Outputs to `src/gqlkit/__generated__/` (schema.ts, resolvers.ts)
-
-### Type Extraction Architecture
-
-Type extraction uses a **2-phase process** to correctly distinguish between type declaration context and field type context:
-
-**Phase 1: Collect Type Names** (`type-name-collector.ts`)
-- Collects all exported type names from schema files
-- Handles direct declarations (type, interface, enum)
-- Handles re-exports: `export type { Foo } from "..."` and `export type * from "..."`
-- Result: `knownTypeNames: ReadonlySet<string>`
-
-**Phase 2: Extract Types and Resolvers**
-- Uses `knownTypeNames` to determine if a type reference should be preserved or expanded
-- `field-type-resolver.ts`: Resolves field types in field context
-- `type-extractor.ts`: Extracts type declarations
-- `define-api-extractor.ts`: Extracts resolver definitions
-
-**Context distinction is critical**:
-
-| Context | Example | Behavior |
-|---------|---------|----------|
-| Type declaration | `export type User = Simplify<DbUser>` | Uses declared name `User` |
-| Field type (known) | `author: User` where `User` is exported | Uses reference `User` |
-| Field type (unknown) | `author: Simplify<DbUser>` where `Simplify` is not exported | Expands to inline object |
-| Intersection in field | `merged: A & B` | Always inline object |
-
-**Key principle**: In field context, only types in `knownTypeNames` are preserved as references. Utility types (Omit, Pick, Simplify, etc.) are expanded to inline objects unless explicitly exported in the schema.
-
-### Design Principles
-
-- **Fail fast with actionable errors**: Invalid resolver references, type mismatches, etc.
-- **No decorators, no runtime schema mutation**: Pure static analysis of TypeScript code
-- **HTTP server integration is out of scope**: Focus on TS → schema AST + resolver map transformation
-- **Deterministic**: Same code → same outputs, always
-- **GraphQL-tools compatible**: Generated outputs work seamlessly with makeExecutableSchema
-
-### TypeScript to GraphQL Type Mapping
-
-| TypeScript | GraphQL |
-|------------|---------|
-| `string` | `String!` |
-| `number` | `Float!` |
-| `boolean` | `Boolean!` |
-| `IDString`, `IDNumber` | `ID!` |
-| `Int` (branded) | `Int!` |
-| `Float` (branded) | `Float!` |
-| `T \| null` | `T` (nullable) |
-| `T[]` | `[T!]!` |
-| String literal union | Enum type |
-| TypeScript `enum` | Enum type |
-| Union of object types | Union type |
-| `*Input` suffix types | Input Object type |
-| Union with `*Input` suffix | `@oneOf` input object |
-| `GqlInterface<T>` | Interface type |
-| `GqlScalar<Name, Base>` | Custom scalar |
+**Package manager**: pnpm (v10.28.0)
 
 ## Development Workflow
 


### PR DESCRIPTION
## Summary

- Simplify CLAUDE.md by replacing duplicated content with references to steering files and user documentation
- Sync steering files with recent codebase changes (inline union/enum auto-generation, SCREAMING_SNAKE_CASE conversion, automatic scalar mapping)
- Update pnpm version to 10.28.0

## Changes

### CLAUDE.md
- Added references to `.kiro/steering/` and `packages/docs/src/content/` for detailed information
- Removed duplicated sections that are now documented in steering files:
  - Convention-Driven Design
  - Monorepo Structure
  - CLI Pipeline
  - Code Generation Flow
  - Type Extraction Architecture
  - Design Principles
  - TypeScript to GraphQL Type Mapping
- Reduced file size from 251 lines to 122 lines

### Steering Files
- **product.md**: Expanded auto-type generation scope (unions, string literal unions)
- **structure.md**: Updated auto-type-generator scope (unions, enums), added mapper pattern
- **tech.md**: Added inline union/enum auto-generation, SCREAMING_SNAKE_CASE conversion, automatic scalar base type mapping

## Test plan

- [x] Verify CLAUDE.md references point to existing files
- [x] Verify steering files are consistent with recent code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)