### PR TITLE
ci: refine test matrix for OS-specific Node.js versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,15 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: ["lts/-1", "lts/*"]
-        os: ["ubuntu-latest", "windows-latest"]
+        include:
+          # ubuntu-latest: LTS active + maintenance
+          - os: ubuntu-latest
+            node-version: "lts/*"
+          - os: ubuntu-latest
+            node-version: "lts/-1"
+          # windows-latest: LTS active only
+          - os: windows-latest
+            node-version: "lts/*"
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: test / Node.js ${{ matrix.node-version }} / ${{ matrix.os }}


### PR DESCRIPTION
## Summary
- ubuntu-latest: test on both active LTS and maintenance LTS
- windows-latest: test on active LTS only
- Reduce test matrix from 4 jobs to 3

## Test plan
- [ ] Verify CI runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)