### PR TITLE
docs: reduce duplication and improve documentation structure

### DIFF
--- a/packages/docs/src/content/_meta.js
+++ b/packages/docs/src/content/_meta.js
@@ -7,11 +7,11 @@ export default {
   },
   "what-is-gqlkit": "What is gqlkit?",
   "getting-started": "Getting Started",
+  configuration: "Configuration",
   "-- Guides": {
     type: "separator",
     title: "Guides",
   },
   schema: "Schema",
   integration: "Integration",
-  configuration: "Configuration",
 };

--- a/packages/docs/src/content/configuration.md
+++ b/packages/docs/src/content/configuration.md
@@ -49,7 +49,7 @@ export default defineConfig({
 
 ## Custom Scalar Types
 
-Map TypeScript types to GraphQL custom scalars via config:
+Map TypeScript types to GraphQL custom scalars via config. See [Scalars](./schema/scalars) for complete documentation including the `GqlScalar` approach.
 
 ```ts
 export default defineConfig({
@@ -59,28 +59,9 @@ export default defineConfig({
       tsType: { from: "./src/gqlkit/schema/scalars", name: "DateTime" },
       description: "ISO 8601 datetime string",
     },
-    {
-      name: "UUID",
-      tsType: { name: "string" },
-      only: "input", // Input-only scalar
-    },
   ],
 });
 ```
-
-### Scalar Options
-
-| Option | Type | Description |
-|--------|------|-------------|
-| `name` | `string` | The GraphQL scalar name |
-| `tsType.name` | `string` | The TypeScript type name |
-| `tsType.from` | `string` (optional) | Import path for the type (omit for global types) |
-| `description` | `string` (optional) | Description for the GraphQL schema |
-| `only` | `"input"` \| `"output"` (optional) | Restrict scalar to input or output positions |
-
-> [!TIP]
->
-> You can also define custom scalars using the `GqlScalar` utility type directly in your schema files. See [Scalars](/schema/scalars) for more details.
 
 ## Output Paths
 

--- a/packages/docs/src/content/getting-started.md
+++ b/packages/docs/src/content/getting-started.md
@@ -66,6 +66,7 @@ export type User = {
   email: string | null;
 };
 
+// NoArgs indicates this query takes no arguments
 export const me = defineQuery<NoArgs, User | null>(
   (_root, _args, ctx) => ctx.currentUser
 );

--- a/packages/docs/src/content/integration/apollo.md
+++ b/packages/docs/src/content/integration/apollo.md
@@ -16,18 +16,9 @@ pnpm add @apollo/server
 yarn add @apollo/server
 ```
 
-## Creating the Schema
+## Prerequisites
 
-First, create an executable schema using `makeExecutableSchema`:
-
-```typescript
-// src/schema.ts
-import { makeExecutableSchema } from "@graphql-tools/schema";
-import { typeDefs } from "./gqlkit/__generated__/schema";
-import { resolvers } from "./gqlkit/__generated__/resolvers";
-
-export const schema = makeExecutableSchema({ typeDefs, resolvers });
-```
+Create an executable schema following the [Getting Started guide](../getting-started.md#create-graphql-schema).
 
 ## Basic Server
 
@@ -50,35 +41,7 @@ console.log(`Server is running on ${url}`);
 
 ## With Context
 
-If your resolvers use a context type, provide a context factory:
-
-```typescript
-// src/gqlkit/context.ts
-export type Context = {
-  currentUser: User | null;
-  db: Database;
-};
-```
-
-```typescript
-// src/gqlkit/gqlkit.ts
-import { createGqlkitApis } from "@gqlkit-ts/runtime";
-import type { Context } from "./context";
-
-export const { defineQuery, defineMutation, defineField } =
-  createGqlkitApis<Context>();
-```
-
-```typescript
-// src/gqlkit/schema/query.ts
-import { defineQuery } from "../gqlkit";
-import type { NoArgs } from "@gqlkit-ts/runtime";
-import type { User } from "./user";
-
-export const me = defineQuery<NoArgs, User | null>(
-  (_root, _args, ctx) => ctx.currentUser
-);
-```
+If your resolvers use a context type, first [set up context and resolver factories](../getting-started.md#set-up-context-and-resolver-factories), then provide a context factory to your server:
 
 ```typescript
 // src/server.ts

--- a/packages/docs/src/content/integration/drizzle.md
+++ b/packages/docs/src/content/integration/drizzle.md
@@ -145,7 +145,7 @@ export const posts = defineField<User, NoArgs, Post[]>(
 
 ## Context with Database
 
-Set up the context type to include your database instance:
+Set up the context type to include your database instance. For basic setup, see [Set Up Context and Resolver Factories](../getting-started.md#set-up-context-and-resolver-factories).
 
 ```typescript
 // src/db/db.ts
@@ -165,15 +165,6 @@ import type { Database } from "../db/db.js";
 export type Context = {
   db: Database;
 };
-```
-
-```typescript
-// src/gqlkit/gqlkit.ts
-import { createGqlkitApis } from "@gqlkit-ts/runtime";
-import type { Context } from "./context.js";
-
-export const { defineQuery, defineMutation, defineField } =
-  createGqlkitApis<Context>();
 ```
 
 ## Complete Example

--- a/packages/docs/src/content/integration/prisma.md
+++ b/packages/docs/src/content/integration/prisma.md
@@ -157,7 +157,7 @@ export const posts = defineField<User, NoArgs, Post[]>(
 
 ## Context with Database
 
-Set up the context type to include your Prisma client instance:
+Set up the context type to include your Prisma client instance. For basic setup, see [Set Up Context and Resolver Factories](../getting-started.md#set-up-context-and-resolver-factories).
 
 ```typescript
 // src/db/db.ts
@@ -174,15 +174,6 @@ import type { PrismaDatabase } from "../db/db.js";
 export type Context = {
   db: PrismaDatabase;
 };
-```
-
-```typescript
-// src/gqlkit/gqlkit.ts
-import { createGqlkitApis } from "@gqlkit-ts/runtime";
-import type { Context } from "./context.js";
-
-export const { defineQuery, defineMutation, defineField } =
-  createGqlkitApis<Context>();
 ```
 
 ## Complete Example

--- a/packages/docs/src/content/integration/yoga.md
+++ b/packages/docs/src/content/integration/yoga.md
@@ -16,18 +16,9 @@ pnpm add graphql-yoga
 yarn add graphql-yoga
 ```
 
-## Creating the Schema
+## Prerequisites
 
-First, create an executable schema using `makeExecutableSchema`:
-
-```typescript
-// src/schema.ts
-import { makeExecutableSchema } from "@graphql-tools/schema";
-import { typeDefs } from "./gqlkit/__generated__/schema";
-import { resolvers } from "./gqlkit/__generated__/resolvers";
-
-export const schema = makeExecutableSchema({ typeDefs, resolvers });
-```
+Create an executable schema following the [Getting Started guide](../getting-started.md#create-graphql-schema).
 
 ## Basic Server
 
@@ -47,35 +38,7 @@ server.listen(4000, () => {
 
 ## With Context
 
-If your resolvers use a context type, provide a context factory:
-
-```typescript
-// src/gqlkit/context.ts
-export type Context = {
-  currentUser: User | null;
-  db: Database;
-};
-```
-
-```typescript
-// src/gqlkit/gqlkit.ts
-import { createGqlkitApis } from "@gqlkit-ts/runtime";
-import type { Context } from "./context";
-
-export const { defineQuery, defineMutation, defineField } =
-  createGqlkitApis<Context>();
-```
-
-```typescript
-// src/gqlkit/schema/query.ts
-import { defineQuery } from "../gqlkit";
-import type { NoArgs } from "@gqlkit-ts/runtime";
-import type { User } from "./user";
-
-export const me = defineQuery<NoArgs, User | null>(
-  (_root, _args, ctx) => ctx.currentUser
-);
-```
+If your resolvers use a context type, first [set up context and resolver factories](../getting-started.md#set-up-context-and-resolver-factories), then provide a context factory to your server:
 
 ```typescript
 // src/server.ts

--- a/packages/docs/src/content/schema/index.md
+++ b/packages/docs/src/content/schema/index.md
@@ -23,6 +23,22 @@ gqlkit maps TypeScript types to GraphQL types as follows:
 | Union with `*Input` suffix | `@oneOf` input object |
 | `GqlInterface<T>` | Interface type |
 | `GqlScalar<Name, Base>` | Custom scalar |
+| `NoArgs` | Indicates resolver takes no arguments |
+
+## Naming Conventions
+
+gqlkit generates type names using predictable conventions:
+
+| Context | Pattern | Example |
+|---------|---------|---------|
+| Object field (inline) | `{ParentType}{Field}` | `User.profile` → `UserProfile` |
+| Input field (inline) | `{ParentWithoutInput}{Field}Input` | `CreateUserInput.address` → `CreateUserAddressInput` |
+| Query/Mutation arg | `{Resolver}{Arg}Input` | `searchUsers(filter)` → `SearchUsersFilterInput` |
+| Field resolver arg | `{Parent}{Field}{Arg}Input` | `User.posts(filter)` → `UserPostsFilterInput` |
+| Inline enum | Same as parent context | `User.status` → `UserStatus` |
+| Payload type | `{Resolver}Payload` | `updateUser` → `UpdateUserPayload` |
+
+For complete details on inline enum naming, see [Inline Enums](./enums.md#inline-enums).
 
 ## Project Layout
 

--- a/packages/docs/src/content/schema/inputs.md
+++ b/packages/docs/src/content/schema/inputs.md
@@ -371,28 +371,4 @@ input CreateUserInput {
 
 ## Invalid Field Names
 
-Input field names that are not valid GraphQL identifiers are automatically skipped with a warning. Valid GraphQL names must:
-
-- Match the pattern `/^[_A-Za-z][_0-9A-Za-z]*$/`
-- Not start with `__` (reserved for GraphQL introspection)
-
-```typescript
-export type CreateUserInput = {
-  name: string;            // ✅ Valid
-  _metadata: string;       // ✅ Valid (single underscore is OK)
-  "123abc": string;        // ⚠️ Skipped: starts with a number
-  __private: string;       // ⚠️ Skipped: starts with __
-  "hyphen-field": string;  // ⚠️ Skipped: contains hyphen
-};
-```
-
-Generates (invalid fields are skipped):
-
-```graphql
-input CreateUserInput {
-  name: String!
-  _metadata: String!
-}
-```
-
-When fields are skipped, gqlkit outputs a warning with the field name and location.
+Input field names follow the same validation rules as object type fields. See [Invalid Field Names](./objects.md#invalid-field-names) for details.

--- a/packages/docs/src/content/schema/queries-mutations.md
+++ b/packages/docs/src/content/schema/queries-mutations.md
@@ -2,28 +2,7 @@
 
 Define Query and Mutation fields using the `@gqlkit-ts/runtime` API.
 
-## Setup
-
-Create `src/gqlkit/context.ts` to define your context type:
-
-```typescript
-export type Context = {
-  userId: string;
-  db: Database;
-};
-```
-
-Create `src/gqlkit/gqlkit.ts` to export resolver factories:
-
-```typescript
-import { createGqlkitApis } from "@gqlkit-ts/runtime";
-import type { Context } from "./context";
-
-export const { defineQuery, defineMutation, defineField } =
-  createGqlkitApis<Context>();
-```
-
-Then import the factories in your schema files.
+> **Prerequisites**: This guide assumes you have completed the [basic setup](../getting-started.md#set-up-context-and-resolver-factories).
 
 ## Query Resolvers
 


### PR DESCRIPTION
## Summary

- Remove duplicated context/resolver factory setup code from 6 files, consolidating to getting-started.md as the single source of truth
- Remove duplicated schema creation code from apollo.md and yoga.md
- Consolidate "Invalid Field Names" section to objects.md, reference from inputs.md
- Add "Naming Conventions" section to schema/index.md for centralized reference
- Add NoArgs to Type Mapping table and explanation in getting-started.md
- Simplify "Custom Scalar Types" section in configuration.md with link to scalars.md
- Move Configuration before Guides section in navigation for better discoverability
- Add cross-references throughout to improve navigation between related topics

## Test plan

- [x] `pnpm build` in packages/docs passes
- [ ] Manually verify links work correctly in the documentation site
- [ ] Review navigation order makes sense for new users

🤖 Generated with [Claude Code](https://claude.com/claude-code)