### PR TITLE
docs(agents): add commit/pr/changeset workflow rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,10 +92,10 @@ When creating command-line interfaces, use the `use-gunshi-cli` skill.
 
 ## Commit and Pull Request Rules
 - Use Conventional Commits for titles: `<type>(<scope>): <description>`.
-- Commit bodies and PR descriptions must include:
+- PR descriptions must include:
   - `Why`: reason for the change.
   - `Summary`: short overview of what changed.
-- If `Why` is unknown, ask the user before finalizing.
+- If `Why` is unknown, ask the user before finalizing the PR description.
 
 ## Changeset Rules
 - First, decide whether a changeset is required for the change before writing one.


### PR DESCRIPTION
## Why
To standardize contribution metadata so commit history, PR context, and release notes stay consistent and easy to review.

## Summary
- Added combined rules for commit and PR writing with required Why and Summary sections.
- Added changeset rules, including deciding necessity first and omitting scope.
- Added breaking-change changeset format using **BREAKING CHANGE** with brief migration guidance.

## Testing
- Documentation-only change; no runtime behavior changes.
- Verified AGENTS.md remains a symlink to CLAUDE.md.
- Verified final diff is append-only for the new rule sections.