### PR TITLE
chore: add changeset for #220

### DIFF
--- a/.changeset/shared-visited-types.md
+++ b/.changeset/shared-visited-types.md
@@ -1,0 +1,7 @@
+---
+"@gqlkit-ts/cli": patch
+---
+
+pr: #220
+
+fix: prevent false-positive cycle detection for shared inline types


### PR DESCRIPTION
## Why

PR #220 was merged without a changeset.

## Summary

- Add missing changeset for #220 (fix false-positive cycle detection for shared inline types)
- This is a `patch` version bump for `@gqlkit-ts/cli`

## Related

- #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)