### PR TITLE
chore: fix Biome lint issues

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -8,6 +8,7 @@
   "files": {
     "includes": [
       "**",
+      "!**/*.md",
       "!**/testdata/**/__generated__",
       "!**/__generated__/prisma"
     ],

--- a/examples/with-ai-sdk/src/scenario.test.ts
+++ b/examples/with-ai-sdk/src/scenario.test.ts
@@ -50,8 +50,20 @@ function createTextStreamModel(): MockLanguageModelV3 {
           { type: "text-end", id: "t1" },
           {
             type: "finish",
-            finishReason: "stop",
-            usage: { inputTokens: {}, outputTokens: {} },
+            finishReason: { unified: "stop", raw: undefined },
+            usage: {
+              inputTokens: {
+                total: 0,
+                noCache: 0,
+                cacheRead: undefined,
+                cacheWrite: undefined,
+              },
+              outputTokens: {
+                total: 0,
+                text: 0,
+                reasoning: undefined,
+              },
+            },
           },
         ] satisfies StreamChunk[],
       }),

--- a/examples/with-ai-sdk/src/scenario.test.ts
+++ b/examples/with-ai-sdk/src/scenario.test.ts
@@ -15,6 +15,13 @@ import { createResolvers } from "./gqlkit/__generated__/resolvers.js";
 import { typeDefs } from "./gqlkit/__generated__/typeDefs.js";
 import type { Context } from "./gqlkit/context.js";
 
+type StreamChunk =
+  Awaited<
+    ReturnType<MockLanguageModelV3["doStream"]>
+  >["stream"] extends ReadableStream<infer T>
+    ? T
+    : never;
+
 // Identity scalars — pass through any value as-is
 const GraphQLJSON = new GraphQLScalarType({ name: "JSON" });
 const GraphQLJSONObject = new GraphQLScalarType({ name: "JSONObject" });
@@ -36,7 +43,6 @@ function createTextStreamModel(): MockLanguageModelV3 {
   return new MockLanguageModelV3({
     doStream: async () => ({
       stream: simulateReadableStream({
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- AI SDK V3 stream part types are complex; cast to avoid deep structural mismatch
         chunks: [
           { type: "text-start", id: "t1" },
           { type: "text-delta", id: "t1", delta: "Hello" },
@@ -47,7 +53,7 @@ function createTextStreamModel(): MockLanguageModelV3 {
             finishReason: "stop",
             usage: { inputTokens: {}, outputTokens: {} },
           },
-        ] as any[],
+        ] satisfies StreamChunk[],
       }),
     }),
   });

--- a/packages/cli/src/gen-orchestrator/testdata/abstract-resolver-non-exported/src/gqlkit/schema/types.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/abstract-resolver-non-exported/src/gqlkit/schema/types.ts
@@ -12,7 +12,7 @@ export interface Post {
 
 export type SearchResult = User | Post;
 
-const searchResultResolveType = defineResolveType<SearchResult>((value) => {
+const _searchResultResolveType = defineResolveType<SearchResult>((value) => {
   if ("name" in value) {
     return "User";
   }

--- a/packages/cli/src/gen-orchestrator/testdata/abstract-resolver-non-exported/src/gqlkit/schema/types.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/abstract-resolver-non-exported/src/gqlkit/schema/types.ts
@@ -12,7 +12,8 @@ export interface Post {
 
 export type SearchResult = User | Post;
 
-const _searchResultResolveType = defineResolveType<SearchResult>((value) => {
+// biome-ignore lint/correctness/noUnusedVariables: This non-exported resolver exists to verify the generator ignores it.
+const searchResultResolveType = defineResolveType<SearchResult>((value) => {
   if ("name" in value) {
     return "User";
   }

--- a/packages/cli/src/gen-orchestrator/testdata/auto-object-resolver-args/src/gqlkit/schema/nested.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/auto-object-resolver-args/src/gqlkit/schema/nested.ts
@@ -26,4 +26,4 @@ export const updateSettings = defineMutation<
     };
   },
   Result
->((_root, args) => ({ success: true }));
+>((_root, _args) => ({ success: true }));

--- a/packages/cli/src/gen-orchestrator/testdata/auto-object-resolver-args/src/gqlkit/schema/types.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/auto-object-resolver-args/src/gqlkit/schema/types.ts
@@ -57,7 +57,7 @@ export const searchUsers = defineQuery<
     };
   },
   User[]
->((_root, args) => []);
+>((_root, _args) => []);
 
 /**
  * Field resolver with inline args for User.posts
@@ -72,4 +72,4 @@ export const posts = defineField<
     } | null;
   },
   Post[]
->((parent, args) => []);
+>((_parent, _args) => []);

--- a/packages/cli/src/gen-orchestrator/testdata/default-value-basic/src/gqlkit/schema/types.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/default-value-basic/src/gqlkit/schema/types.ts
@@ -1,4 +1,4 @@
-import type { GqlField, Int, NoArgs } from "@gqlkit-ts/runtime";
+import type { GqlField, Int } from "@gqlkit-ts/runtime";
 import { defineQuery } from "../gqlkit.js";
 
 export type PaginationInput = {

--- a/packages/cli/src/gen-orchestrator/testdata/default-value-complex/src/gqlkit/schema/types.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/default-value-complex/src/gqlkit/schema/types.ts
@@ -1,4 +1,4 @@
-import type { GqlField, Int, NoArgs } from "@gqlkit-ts/runtime";
+import type { GqlField, Int } from "@gqlkit-ts/runtime";
 import { defineQuery } from "../gqlkit.js";
 
 export type Status = "ACTIVE" | "INACTIVE" | "PENDING";

--- a/packages/cli/src/gen-orchestrator/testdata/default-value-errors/src/gqlkit/schema/types.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/default-value-errors/src/gqlkit/schema/types.ts
@@ -1,4 +1,4 @@
-import type { GqlField, Int, NoArgs } from "@gqlkit-ts/runtime";
+import type { GqlField, Int } from "@gqlkit-ts/runtime";
 import { defineQuery } from "../gqlkit.js";
 
 export type BadInput = {

--- a/packages/cli/src/gen-orchestrator/testdata/discriminator-field-duplicate-value-tuple/src/gqlkit/schema/query.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/discriminator-field-duplicate-value-tuple/src/gqlkit/schema/query.ts
@@ -1,7 +1,8 @@
+import type { NoArgs } from "@gqlkit-ts/runtime";
 import { defineQuery } from "../gqlkit.js";
 import type { Content } from "./types.js";
 
-export const contentQuery = defineQuery<Content[], {}>(
+export const contentQuery = defineQuery<Content[], NoArgs>(
   "content",
   (_args, _ctx) => {
     return [{ type: "text", subType: "plain", bodyA: "hello" }];

--- a/packages/cli/src/gen-orchestrator/testdata/discriminator-field-validation-error/src/gqlkit/schema/query.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/discriminator-field-validation-error/src/gqlkit/schema/query.ts
@@ -1,13 +1,17 @@
+import type { NoArgs } from "@gqlkit-ts/runtime";
 import { defineQuery } from "../gqlkit.js";
 import type { ContentPart, Media } from "./types.js";
 
-export const contentQuery = defineQuery<ContentPart[], {}>(
+export const contentQuery = defineQuery<ContentPart[], NoArgs>(
   "content",
   (_args, _ctx) => {
     return [{ type: "text", text: "hello" }];
   },
 );
 
-export const mediaQuery = defineQuery<Media[], {}>("media", (_args, _ctx) => {
-  return [{ kind: "audio", url: "https://example.com/audio.mp3" }];
-});
+export const mediaQuery = defineQuery<Media[], NoArgs>(
+  "media",
+  (_args, _ctx) => {
+    return [{ kind: "audio", url: "https://example.com/audio.mp3" }];
+  },
+);

--- a/packages/cli/src/gen-orchestrator/testdata/field-resolver/src/gqlkit/schema/user.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/field-resolver/src/gqlkit/schema/user.ts
@@ -12,4 +12,4 @@ export interface Post {
   authorId: string;
 }
 
-export const posts = defineField<User, NoArgs, Post[]>((parent) => []);
+export const posts = defineField<User, NoArgs, Post[]>((_parent) => []);

--- a/packages/cli/src/gen-orchestrator/testdata/gqlfield-def-unwrap-bug/src/gqlkit/schema/types.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/gqlfield-def-unwrap-bug/src/gqlkit/schema/types.ts
@@ -1,4 +1,4 @@
-import type { GqlField, Int, NoArgs } from "@gqlkit-ts/runtime";
+import type { GqlField, Int } from "@gqlkit-ts/runtime";
 import { defineQuery } from "../gqlkit.js";
 
 // Bug 1: Type reference (NestedConfig) should resolve to actual type name, not __type

--- a/packages/cli/src/gen-orchestrator/testdata/ignore-fields-input/src/gqlkit/schema/mutation.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/ignore-fields-input/src/gqlkit/schema/mutation.ts
@@ -2,5 +2,5 @@ import { defineMutation } from "../gqlkit.js";
 import type { CreateUserInput, User } from "./types.js";
 
 export const createUser = defineMutation<{ input: CreateUserInput }, User>(
-  () => ({ id: "1" as any, name: "Test", email: "test@example.com" }),
+  () => ({ id: "1", name: "Test", email: "test@example.com" }),
 );

--- a/packages/cli/src/gen-orchestrator/testdata/inline-payload-union-mixed/src/gqlkit/schema/types.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/inline-payload-union-mixed/src/gqlkit/schema/types.ts
@@ -3,7 +3,6 @@ import {
   defineIsTypeOf,
   defineMutation,
   defineQuery,
-  defineResolveType,
   type NoArgs,
 } from "../gqlkit.js";
 

--- a/packages/cli/src/gen-orchestrator/testdata/inline-payload-union-typename-dedup/src/gqlkit/schema/types.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/inline-payload-union-typename-dedup/src/gqlkit/schema/types.ts
@@ -1,9 +1,4 @@
-import {
-  defineIsTypeOf,
-  defineMutation,
-  defineQuery,
-  type NoArgs,
-} from "../gqlkit.js";
+import { defineIsTypeOf, defineMutation, defineQuery } from "../gqlkit.js";
 
 /**
  * User type - named type for success case.

--- a/packages/cli/src/gen-orchestrator/testdata/interface-basic/src/gqlkit/schema/query.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/interface-basic/src/gqlkit/schema/query.ts
@@ -1,4 +1,4 @@
-import type { NoArgs, QueryResolver } from "@gqlkit-ts/runtime";
+import type { NoArgs } from "@gqlkit-ts/runtime";
 import { defineQuery } from "../gqlkit.js";
 import type { User } from "./user.js";
 

--- a/packages/cli/src/gen-orchestrator/testdata/interface-resolver/src/gqlkit/schema/query.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/interface-resolver/src/gqlkit/schema/query.ts
@@ -6,5 +6,5 @@ import type { User } from "./user.js";
 export const users = defineQuery<NoArgs, User[]>(() => []);
 
 export const node = defineQuery<{ id: string }, Node | null>(
-  (_, { id }) => null,
+  (_root, _args) => null,
 );

--- a/packages/cli/src/gen-orchestrator/testdata/numeric-enum-input/src/gqlkit/schema/types.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/numeric-enum-input/src/gqlkit/schema/types.ts
@@ -1,6 +1,6 @@
 import { createGqlkitApis } from "@gqlkit-ts/runtime";
 
-const { defineMutation } = createGqlkitApis<{}>();
+const { defineMutation } = createGqlkitApis<Record<string, never>>();
 
 /**
  * User status enum with numeric values.

--- a/packages/cli/src/gen-orchestrator/testdata/numeric-enum-interface/src/gqlkit/schema/types.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/numeric-enum-interface/src/gqlkit/schema/types.ts
@@ -1,7 +1,7 @@
 import type { GqlInterface, GqlObject } from "@gqlkit-ts/runtime";
-import { createGqlkitApis, type NoArgs } from "@gqlkit-ts/runtime";
+import { createGqlkitApis } from "@gqlkit-ts/runtime";
 
-const { defineResolveType } = createGqlkitApis<{}>();
+const { defineResolveType } = createGqlkitApis<Record<string, never>>();
 
 /**
  * User status enum with numeric values.
@@ -32,4 +32,4 @@ export type User = GqlObject<
   { implements: [Node] }
 >;
 
-export const resolveNodeType = defineResolveType<Node>((obj) => "User");
+export const resolveNodeType = defineResolveType<Node>((_obj) => "User");

--- a/packages/cli/src/gen-orchestrator/testdata/numeric-enum-user-resolver/src/gqlkit/schema/types.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/numeric-enum-user-resolver/src/gqlkit/schema/types.ts
@@ -1,6 +1,6 @@
 import { createGqlkitApis, type NoArgs } from "@gqlkit-ts/runtime";
 
-const { defineField } = createGqlkitApis<{}>();
+const { defineField } = createGqlkitApis<Record<string, never>>();
 
 /**
  * User status enum with numeric values.

--- a/packages/cli/src/gen-orchestrator/testdata/oneof-errors/src/gqlkit/schema/errors.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/oneof-errors/src/gqlkit/schema/errors.ts
@@ -7,7 +7,7 @@ export type MultiplePropertiesInput =
   | { id: string; name: string }
   | { code: string };
 
-export type EmptyObjectInput = {} | { id: string };
+export type EmptyObjectInput = Record<string, never> | { id: string };
 
 export type DuplicatePropertyInput = { id: string } | { id: number };
 

--- a/packages/cli/src/gen-orchestrator/testdata/scalar-base-type-mapping/src/gqlkit/schema/query.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/scalar-base-type-mapping/src/gqlkit/schema/query.ts
@@ -1,6 +1,6 @@
 import type { NoArgs } from "@gqlkit-ts/runtime";
 import { defineQuery } from "../gqlkit.js";
-import type { CreateEventInput, Event } from "./event.js";
+import type { Event } from "./event.js";
 
 /**
  * Query resolver returning events.

--- a/packages/cli/src/gen-orchestrator/testdata/skip-invalid-graphql-names-inline/src/gqlkit/schema/nested.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/skip-invalid-graphql-names-inline/src/gqlkit/schema/nested.ts
@@ -20,4 +20,4 @@ export const updateSettings = defineMutation<
     };
   },
   Result
->((_root, args) => ({ success: true }));
+>((_root, _args) => ({ success: true }));

--- a/packages/cli/src/gen-orchestrator/testdata/skip-invalid-graphql-names-inline/src/gqlkit/schema/types.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/skip-invalid-graphql-names-inline/src/gqlkit/schema/types.ts
@@ -43,7 +43,7 @@ export const searchUsers = defineQuery<
     };
   },
   User[]
->((_root, args) => []);
+>((_root, _args) => []);
 
 export const posts = defineField<
   User,
@@ -55,4 +55,4 @@ export const posts = defineField<
     } | null;
   },
   Post[]
->((parent, args) => []);
+>((_parent, _args) => []);

--- a/packages/cli/src/gen-orchestrator/testdata/tsdoc-description/src/gqlkit/schema/query.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/tsdoc-description/src/gqlkit/schema/query.ts
@@ -1,4 +1,3 @@
-import type { NoArgs } from "@gqlkit-ts/runtime";
 import { defineQuery } from "../gqlkit.js";
 
 interface User {
@@ -11,5 +10,5 @@ interface User {
  * Fetch a user by ID.
  */
 export const user = defineQuery<{ id: string }, User | null>(
-  (_root, args) => null,
+  (_root, _args) => null,
 );

--- a/packages/cli/src/gen-orchestrator/testdata/type-alias-reexport/src/gqlkit/gqlkit.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/type-alias-reexport/src/gqlkit/gqlkit.ts
@@ -1,4 +1,4 @@
 import { createGqlkitApis } from "@gqlkit-ts/runtime";
 
 export const { defineQuery, defineMutation, defineField } =
-  createGqlkitApis<{}>();
+  createGqlkitApis<Record<string, never>>();

--- a/packages/cli/src/gen-orchestrator/testdata/type-alias-simplify-field/src/gqlkit/gqlkit.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/type-alias-simplify-field/src/gqlkit/gqlkit.ts
@@ -1,4 +1,4 @@
 import { createGqlkitApis } from "@gqlkit-ts/runtime";
 
 export const { defineQuery, defineMutation, defineField } =
-  createGqlkitApis<{}>();
+  createGqlkitApis<Record<string, never>>();

--- a/packages/cli/src/gen-orchestrator/testdata/type-alias-simplify-union/src/gqlkit/gqlkit.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/type-alias-simplify-union/src/gqlkit/gqlkit.ts
@@ -1,4 +1,4 @@
 import { createGqlkitApis } from "@gqlkit-ts/runtime";
 
 export const { defineQuery, defineMutation, defineField, defineResolveType } =
-  createGqlkitApis<{}>();
+  createGqlkitApis<Record<string, never>>();

--- a/packages/cli/src/gen-orchestrator/testdata/union-type/src/gqlkit/schema/query.ts
+++ b/packages/cli/src/gen-orchestrator/testdata/union-type/src/gqlkit/schema/query.ts
@@ -1,4 +1,3 @@
-import type { NoArgs } from "@gqlkit-ts/runtime";
 import { defineQuery } from "../gqlkit.js";
 
 type SearchResult = { id: string; name?: string; title?: string };

--- a/packages/cli/src/shared/directive-definition-extractor.ts
+++ b/packages/cli/src/shared/directive-definition-extractor.ts
@@ -106,7 +106,7 @@ function extractDirectiveName(
 
   const rawNameType = checker.getTypeOfSymbol(nameProp);
   const nameType = getActualMetadataType(rawNameType);
-  if (!nameType || !nameType.isStringLiteral()) {
+  if (!nameType?.isStringLiteral()) {
     return null;
   }
 

--- a/packages/cli/src/shared/directive-detector.ts
+++ b/packages/cli/src/shared/directive-detector.ts
@@ -240,7 +240,7 @@ function extractDirectiveFromType(
 
   const rawNameType = checker.getTypeOfSymbol(nameProp);
   const nameType = getActualMetadataType(rawNameType);
-  if (!nameType || !nameType.isStringLiteral()) {
+  if (!nameType?.isStringLiteral()) {
     return { directive: null, errors: [] };
   }
 

--- a/packages/cli/src/shared/interface-validator.ts
+++ b/packages/cli/src/shared/interface-validator.ts
@@ -191,7 +191,7 @@ function findCircularReference(
   path.push(typeName);
 
   const type = typeMap.get(typeName);
-  if (!type || !type.implementedInterfaces) {
+  if (!type?.implementedInterfaces) {
     return null;
   }
 


### PR DESCRIPTION
Why
- Biome reported lint and formatting issues across test fixtures, shared utilities, and the example AI SDK test setup.
- The current `biome.jsonc` schema version was also out of sync with the installed CLI, and Markdown files under `.claude` were being included in checks even though Biome does not support them in this configuration.

Summary
- Replaced `{} ` argument types that were effectively no-arg inputs with `NoArgs`, and tightened other empty-object usages to explicit object types where appropriate.
- Removed unused imports and parameters in testdata fixtures, replaced explicit `any` usage in the AI SDK scenario test with an inferred stream chunk type, and applied the optional-chain cleanups flagged in shared utilities.
- Updated `biome.jsonc` to the current schema version and excluded Markdown files from Biome checks so the repository check command completes cleanly.

Impact
- `pnpm exec biome lint . --max-diagnostics=200`
- `pnpm exec biome check . --max-diagnostics=200`

This PR only changes lint-driven code and configuration cleanup. It does not intentionally change runtime behavior.