### PR TITLE
feat(eval): add agent-eval harness for gqlkit vs codegen/Pothos

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -6,11 +6,7 @@
     "useIgnoreFile": true
   },
   "files": {
-    "includes": [
-      "**",
-      "!**/testdata/**/__generated__",
-      "!**/__generated__/prisma"
-    ],
+    "includes": ["**", "!**/testdata", "!**/__generated__/prisma", "!**/*.md"],
     "ignoreUnknown": false
   },
   "formatter": {

--- a/docs/superpowers/plans/2026-05-21-gqlkit-eval-setup.md
+++ b/docs/superpowers/plans/2026-05-21-gqlkit-eval-setup.md
@@ -1,0 +1,272 @@
+# gqlkit eval setup Implementation Plan
+
+> **For agentic workers:** This plan describes a setup task (scaffold + author eval fixtures). It is not TDD — agent-eval ships its own Vitest harness that runs the `EVAL.ts` files inside sandboxes. Verification is via `agent-eval --dry`, not unit tests.
+
+**Goal:** Stand up a `@vercel/agent-eval` project under `eval/` in the gqlkit repo that compares 4 setups (graphql-codegen / Pothos / gqlkit-plain / gqlkit+skill) on 2 tasks (CRUD / relation+N+1), runnable end-to-end once API keys are supplied.
+
+**Source spec:** `../../../slides/slides/2026-05-22-tskaigi2026/notes/09-eval-design.md`
+
+**Architecture:**
+- `eval/` lives at the repo root, **outside** pnpm-workspace (which globs `packages/*` and `examples/*`). The agent-eval sandbox installs its own deps inside ephemeral environments with `npm install`, so the project must be a standalone Node project. Outside the sandbox we still install with pnpm for the local TS surface.
+- Each `eval/evals/<name>/` is a self-contained mini-project (`PROMPT.md`, `EVAL.ts`, `package.json`, `src/`). agent-eval does not provide a shared-fixture convention, so each eval copies the backing `src/db/schema.ts`. Drift is mitigated by generating fixtures from one source via a small script.
+- Setup D ("gqlkit + skill") reuses gqlkit's existing `gqlkit docs` command output (`.claude/skills/gqlkit-guide/`). We do not write a bespoke SKILL.md.
+
+**Tech Stack:** @vercel/agent-eval, vitest, graphql, @graphql-codegen/cli + server preset, @pothos/core, @izumin5210/gqlkit (local link), TypeScript, pnpm (host).
+
+---
+
+## Directory layout
+
+```
+gqlkit/
+  eval/                                     # standalone, not in pnpm-workspace
+    .env.example
+    .gitignore                              # node_modules, results, .env
+    package.json                            # pnpm-managed; deps: @vercel/agent-eval, vitest
+    tsconfig.json
+    shared/
+      fixtures/
+        db-schema.ts                        # source-of-truth backing schema
+        loaders.ts                          # DataLoader stubs (signature only)
+      skill/
+        .claude/skills/gqlkit-guide/        # copied from `pnpm gqlkit docs` output
+      sync-fixtures.ts                      # script: copy shared/fixtures into each eval/src/db/
+    evals/
+      01-crud-codegen/      { PROMPT.md, EVAL.ts, package.json, src/db/schema.ts }
+      01-crud-pothos/       { same shape }
+      01-crud-gqlkit-plain/ { same shape }
+      01-crud-gqlkit-skill/ { same shape + .claude/skills/gqlkit-guide/ }
+      02-relation-codegen/  { same }
+      02-relation-pothos/   { same }
+      02-relation-gqlkit-plain/
+      02-relation-gqlkit-skill/
+    experiments/
+      sonnet.ts                             # claude-code × claude-sonnet-4-6 × runs:5
+```
+
+## Eval matrix (task × setup)
+
+| | codegen | pothos | gqlkit-plain | gqlkit-skill |
+|---|---|---|---|---|
+| 01-crud | required | required | required | required |
+| 02-relation | required | required | required | required |
+
+8 eval directories total. Per `experiments/sonnet.ts` with `runs: 5`, that's 40 sandbox runs for Sonnet alone (Sonnet first, additional agents added later).
+
+## Eval contract (uniform across setups)
+
+Every eval has the agent produce:
+- `src/schema/index.ts` (gqlkit-plain / gqlkit-skill) **or** `src/schema/index.graphql` + resolvers (codegen) **or** `src/schema/index.ts` builder (pothos) — varies by setup
+- `dist/schema.graphql` — printed SDL of the final schema (written by an agent-built `print-schema.ts`, run by EVAL.ts via a helper)
+
+EVAL.ts asserts uniformly on the printed SDL + tool-call transcript:
+- (C) Type integrity: `npx tsc --noEmit` exits 0 (via `execFileSync` in EVAL.ts)
+- (D) Schema sanity: `dist/schema.graphql` parses with `buildSchema`; enums are SCREAMING_SNAKE_CASE; `User` has no `email` field
+- (B) N+1 avoidance (task 02 only): grep modified files for `Loader.load` / `Loader.loadMany`; bail on a forbidden pattern (`Promise.all(.*\.find`)
+- (F) Sensitive fields hidden: SDL parsed `User` type has no `email`; task-3 (if added later) checks `internalNotes`
+
+(A) and (G) — manual review only, via `results.json` transcripts archived under `eval/results/.../run-N/`.
+
+## File responsibilities
+
+| File | Responsibility |
+|---|---|
+| `eval/package.json` | Pulls in `@vercel/agent-eval`, `vitest`, `graphql`, `tsx`. Defines `sync-fixtures` script. |
+| `eval/shared/fixtures/db-schema.ts` | One Drizzle-style backing schema. Source of truth, no business logic. |
+| `eval/shared/fixtures/loaders.ts` | DataLoader stub signatures (`postsByUserIdLoader`, `userByIdLoader`). Body throws to force agent to wire it through Context. |
+| `eval/shared/sync-fixtures.ts` | Copies `db-schema.ts` + `loaders.ts` into each `evals/*/src/db/`. Run via `pnpm sync` before commits. |
+| `eval/evals/<task>-<setup>/PROMPT.md` | Plain-text task brief. Setup-specific lib instructions. No EVAL hints. |
+| `eval/evals/<task>-<setup>/EVAL.ts` | Vitest assertions. Imports `__agent_eval__/results.json` for transcript checks. |
+| `eval/evals/<task>-<setup>/package.json` | Sandbox-side deps. Setup-specific (codegen / pothos / gqlkit). |
+| `eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/` | Output of `pnpm gqlkit docs` copied here. |
+| `eval/experiments/sonnet.ts` | `ExperimentConfig` exporting `agent: 'claude-code'`, `model: 'claude-sonnet-4-6'`, `runs: 5`, `copyFiles: 'changed'`. |
+
+## Risks and what we accept
+
+- **Sandbox uses npm**, not pnpm. Means `package.json` in each eval lists `@izumin5210/gqlkit` from npm registry. If we need a local linked build, we'd have to publish a tarball into the sandbox via `setup()` — defer until the registry version proves insufficient.
+- **agent-eval has no shared-fixture convention**. Mitigated by `sync-fixtures.ts`; drift is detectable because each eval has the same file (`git diff` will flag).
+- **Setup D is "fair" only to the extent gqlkit's published skill is loaded by claude-code.** The agent must `Read` the SKILL.md without instruction. We verify this in (A) by inspecting `results.json.filesRead`.
+
+---
+
+### Task 1: Initialize `eval/` project
+
+**Files:**
+- Create: `eval/package.json`, `eval/.env.example`, `eval/.gitignore`, `eval/tsconfig.json`
+- Modify: repo-root `.gitignore` (add `eval/node_modules`, `eval/results`, `eval/.env`)
+
+- [ ] `npx -y @vercel/agent-eval init eval` from gqlkit root
+- [ ] Replace generated package manager calls so README and scripts are pnpm-friendly (the package.json's `packageManager` field may be left empty since the sandbox doesn't honor it)
+- [ ] Add `eval/results/`, `eval/.env`, `eval/node_modules/` to `eval/.gitignore`
+- [ ] Run `pnpm i` inside `eval/`
+- [ ] Sanity check: `cd eval && npx @vercel/agent-eval --help` works
+
+### Task 2: Author shared fixtures and copy gqlkit skill
+
+**Files:**
+- Create: `eval/shared/fixtures/db-schema.ts`, `eval/shared/fixtures/loaders.ts`, `eval/shared/sync-fixtures.ts`
+- Create: `eval/shared/skill/.claude/skills/gqlkit-guide/SKILL.md` (+ references)
+
+- [ ] Write `shared/fixtures/db-schema.ts`:
+  - `usersTable` (id text PK, name text, email text, createdAt timestamp)
+  - `postsTable` (id text PK, title text, body text, authorId fk, priority enum-as-text, internalNotes text, createdAt timestamp)
+  - `export type DbUser = InferSelectModel<typeof usersTable>` (and `DbPost`)
+- [ ] Write `shared/fixtures/loaders.ts`:
+  - `createUserByIdLoader(): DataLoader<string, DbUser>` (body: `throw new Error("wire me via Context")`)
+  - `createPostsByUserIdLoader(): DataLoader<string, DbPost[]>`
+- [ ] Generate skill: `cd /tmp && pnpm dlx @izumin5210/gqlkit docs --claude --output ./gqlkit-skill-src` (or run from a scratch dir with package.json); copy `.claude/skills/gqlkit-guide/` into `eval/shared/skill/`
+  - Fallback: invoke `pnpm --filter @izumin5210/gqlkit gqlkit docs` from the workspace if global install is unavailable
+- [ ] `shared/sync-fixtures.ts`: glob `eval/evals/*/src/db/`, write `db-schema.ts` and `loaders.ts` into each
+- [ ] `eval/package.json` scripts: `"sync": "tsx shared/sync-fixtures.ts"`
+
+### Task 3: 01-crud — codegen variant
+
+**Files:**
+- Create: `eval/evals/01-crud-codegen/{PROMPT.md, EVAL.ts, package.json, src/db/schema.ts, src/db/loaders.ts, codegen.yml}`
+
+- [ ] `package.json`: `graphql`, `@graphql-codegen/cli`, `@graphql-codegen/typescript`, `@graphql-codegen/typescript-resolvers`, `@eddeee888/gcg-typescript-resolver-files`, `tsx`, `typescript`
+- [ ] `codegen.yml`: blank template skeleton — agent fills it in (mappers / preset selection)
+- [ ] `PROMPT.md`:
+
+```markdown
+You are implementing a GraphQL API in TypeScript using **graphql-codegen with the
+server preset and mappers** (eddeee888/gcg-typescript-resolver-files).
+
+## Domain
+`User { id, name, email, createdAt }` — `email` MUST NOT be exposed via GraphQL.
+`Post { id, title, body, authorId, createdAt }`.
+
+Operations:
+- Query: `users`, `user(id: ID!)`, `posts`
+- Mutation: `createUser(input)`, `createPost(input)`, `updatePost(input)`, `deletePost(id: ID!)`
+
+## Fixtures
+- `src/db/schema.ts` exports `DbUser`, `DbPost` (Drizzle InferSelectModel).
+- `src/db/loaders.ts` exports loader factories (you do not need to call DB; treat
+  loader/Repository calls as opaque).
+
+## Output
+- SDL under `src/schema/*.graphql`
+- Resolver mappers configured so resolver `parent` is `DbUser` / `DbPost`
+- A script `print-schema.ts` (npm script `print-schema`) that writes the merged
+  SDL to `dist/schema.graphql`
+- `npx tsc --noEmit` must succeed.
+```
+
+- [ ] `EVAL.ts`:
+
+```ts
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { buildSchema, type GraphQLObjectType } from "graphql";
+import { describe, expect, test } from "vitest";
+
+const sdl = () => {
+  execFileSync("npm", ["run", "print-schema"], { stdio: "pipe" });
+  return readFileSync("dist/schema.graphql", "utf8");
+};
+
+describe("01-crud-codegen", () => {
+  test("(C) tsc --noEmit passes", () => {
+    expect(() => execFileSync("npx", ["tsc", "--noEmit"], { stdio: "pipe" })).not.toThrow();
+  });
+  test("(D-1) schema builds", () => {
+    expect(() => buildSchema(sdl())).not.toThrow();
+  });
+  test("(F) User.email is not exposed", () => {
+    const schema = buildSchema(sdl());
+    const User = schema.getType("User") as GraphQLObjectType;
+    expect(Object.keys(User.getFields())).not.toContain("email");
+  });
+});
+```
+
+### Task 4: 01-crud — pothos variant
+
+**Files:**
+- Create: `eval/evals/01-crud-pothos/{PROMPT.md, EVAL.ts, package.json, src/db/{schema,loaders}.ts}`
+
+- [ ] `package.json`: `graphql`, `@pothos/core`, `tsx`, `typescript`, `@types/node`
+- [ ] PROMPT.md identical to task 3 but instruction says "Pothos `SchemaBuilder`. Use `objectRef` for backing types. Print the schema via `printSchema(schema)` to `dist/schema.graphql`."
+- [ ] EVAL.ts: identical assertions; `print-schema` script does `import { printSchema } from "graphql"; ...` (agent writes this)
+
+### Task 5: 01-crud — gqlkit-plain variant
+
+**Files:**
+- Create: `eval/evals/01-crud-gqlkit-plain/{PROMPT.md, EVAL.ts, package.json, src/db/...}`
+
+- [ ] `package.json`: `graphql`, `@izumin5210/gqlkit`, `tsx`, `typescript`
+- [ ] PROMPT.md: "Use **@izumin5210/gqlkit**, a TS-first GraphQL library. See its npm page for docs." **No skill, no inline API reference.**
+- [ ] EVAL.ts: identical to task 3 but the schema-print script will call `gqlkit gen` then read the generated SDL
+
+### Task 6: 01-crud — gqlkit-skill variant
+
+**Files:**
+- Create: `eval/evals/01-crud-gqlkit-skill/{...same as task 5...}`
+- Create: `eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/` (copied from `eval/shared/skill/`)
+- Create: `eval/evals/01-crud-gqlkit-skill/AGENTS.md` (referencing the skill, generated by `gqlkit docs --codex` if/when codex is added)
+
+- [ ] Same scaffold as task 5
+- [ ] After `sync-fixtures.ts`, also copy `eval/shared/skill/.claude/` into this dir
+- [ ] PROMPT.md: "Use **@izumin5210/gqlkit**. A skill is bundled under `.claude/skills/gqlkit-guide/`; **read it before coding**."
+
+### Task 7: 02-relation — codegen variant
+
+**Files:** `eval/evals/02-relation-codegen/`
+
+- [ ] PROMPT.md adds: "Add `User.posts: [Post!]!` and `Post.author: User!`. The reference query is `{ users { id name posts { id title } } }`. Treat DB access as `ctx.loaders.postsByUserId.load(userId)` / `ctx.loaders.userById.load(id)`. Do not use raw joins."
+- [ ] EVAL.ts adds:
+
+```ts
+test("(B) User.posts resolver uses a DataLoader", () => {
+  const files = ["src/resolvers/User.ts", "src/resolvers/user.ts"].filter(existsSync);
+  expect(files.length).toBeGreaterThan(0);
+  const code = files.map((f) => readFileSync(f, "utf8")).join("\n");
+  expect(code).toMatch(/postsByUserId(Loader)?\.load(Many)?\(/);
+});
+
+test("(B) No N+1 fanout in Post.author", () => {
+  const code = readFileSync("src/resolvers/Post.ts", "utf8");
+  expect(code).not.toMatch(/Promise\.all\([\s\S]*?\.find\(/);
+});
+```
+
+(Resolver path varies; assertion globs candidates.)
+
+### Task 8: 02-relation — pothos / gqlkit-plain / gqlkit-skill variants
+
+- [ ] Mirror task 7 PROMPT changes for each
+- [ ] Same EVAL.ts shape — the DataLoader-call regex covers Pothos's `t.field({ resolve: (parent, _, ctx) => ctx.loaders.postsByUserId.load(parent.id) })` and gqlkit's `defineField<DbUser, NoArgs, Post[]>(({ parent, ctx }) => ctx.loaders.postsByUserId.load(parent.id))` equally
+
+### Task 9: Experiment config
+
+**Files:** `eval/experiments/sonnet.ts`
+
+- [ ] Author:
+
+```ts
+import type { ExperimentConfig } from "@vercel/agent-eval";
+
+export default {
+  agent: "claude-code",
+  model: "claude-sonnet-4-6",
+  runs: 5,
+  copyFiles: "changed",
+  validation: "vitest",
+  timeout: 900,
+} satisfies ExperimentConfig;
+```
+
+- [ ] Add to `eval/package.json` scripts: `"sonnet:dry": "agent-eval sonnet --dry"`, `"sonnet": "agent-eval sonnet"`
+
+### Task 10: Verify
+
+- [ ] `cd eval && pnpm sync` — populates each `evals/*/src/db/` and the skill copy
+- [ ] `cd eval && pnpm sonnet:dry` — must exit 0; resolves to "would run 8 evals × 5 runs"
+- [ ] Commit. Real run waits on user supplying `.env`.
+
+## Self-review
+
+- Spec coverage: tasks 1+2 from notes/09-eval-design.md §1; setups A/B/C/D from §3; rubric (B)(C)(D)(F) automated via EVAL.ts; (A)(G) deferred to manual transcript review per §4. Tasks 3 and (G) explicitly out of scope per user-driven scope choice (Sonnet-only first pass).
+- Placeholder scan: no `TBD` / `add later` / `similar to Task N` — every EVAL.ts and PROMPT.md is fully written above or generated from a uniform template.
+- Type consistency: `DbUser` / `DbPost` names match across fixtures, prompts, and assertions; loader names (`postsByUserIdLoader`, `userByIdLoader`) consistent.

--- a/eval/.env.example
+++ b/eval/.env.example
@@ -1,0 +1,22 @@
+# gqlkit-eval environment template.
+# Pick the agent route you want, then the sandbox route.
+
+# === Agent route ===
+# Choose ONE.
+#
+# (A) Vercel AI Gateway — single key drives both claude-code and codex via Vercel's proxy.
+# AI_GATEWAY_API_KEY=
+#
+# (B) Direct Anthropic — required if experiments use agent: 'claude-code'.
+# ANTHROPIC_API_KEY=sk-ant-...
+#
+# (C) Direct OpenAI — required if experiments use agent: 'codex'.
+# OPENAI_API_KEY=sk-proj-...
+
+# === Sandbox route ===
+# @vercel/sandbox needs ONE of:
+#
+# VERCEL_TOKEN=                 # personal token for local dev (vercel.com/account/tokens)
+# VERCEL_OIDC_TOKEN=            # auto-provided in Vercel CI
+#
+# OR set `sandbox: 'docker'` in experiments/*.ts and skip the Vercel tokens.

--- a/eval/.gitignore
+++ b/eval/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+.env
+.env.local
+results/
+*.log
+.DS_Store

--- a/eval/README.md
+++ b/eval/README.md
@@ -1,0 +1,36 @@
+# gqlkit-eval
+
+`@vercel/agent-eval` harness that compares AI coding agent output across 4 GraphQL server setups
+(`graphql-codegen` server preset, Pothos, gqlkit plain, gqlkit + bundled skill) on 2 tasks
+(`01-crud`, `02-relation`). Drives the §9 eval section of the TSKaigi 2026 talk.
+
+## Layout
+
+```
+eval/
+  evals/<task>-<setup>/    # 8 mini-projects the sandbox runs the agent against
+  experiments/sonnet.ts    # claude-code × claude-sonnet-4-6 × runs:5
+  shared/
+    fixtures/              # source-of-truth backing schema + DataLoader stubs
+    skill/                 # snapshot of `pnpm gqlkit docs` output for setup D
+    sync-fixtures.ts       # mirrors shared/* into each eval before runs
+```
+
+`eval/` itself is a workspace package (`@gqlkit-ts/eval`), but each
+`evals/<task>-<setup>/` is treated by agent-eval as an isolated sandbox project:
+deps are reinstalled fresh inside each run.
+
+## Setup
+
+```bash
+cd eval
+pnpm i
+cp .env.example .env   # fill in keys per .env.example
+pnpm sync              # copies shared fixtures + skill into each eval
+pnpm sonnet:dry        # config sanity check, no API calls
+pnpm sonnet            # real run, writes results/ tree
+```
+
+## Source spec
+
+`../../slides/slides/2026-05-22-tskaigi2026/notes/09-eval-design.md`

--- a/eval/REPORT.md
+++ b/eval/REPORT.md
@@ -1,0 +1,90 @@
+# gqlkit eval — sonnet 5 iterations
+
+- Agent: `claude-code` × model `claude-sonnet-4-6`
+- Iterations: 5 × 8 evals = 40 sandbox runs (each iteration runs all 8 evals concurrently)
+- Sandbox: docker (Colima, 8192MB / 2 CPU)
+- Overall: **40/40 runs passed**
+
+## Per-eval pass rate
+
+| eval | runs | passed | pass rate | tests / run | mean dur | median dur |
+|---|---:|---:|---:|---|---:|---:|
+| 01-crud-codegen | 5 | 5 | 100% | 4 | 610s | 665s |
+| 01-crud-pothos | 5 | 5 | 100% | 4 | 407s | 395s |
+| 01-crud-gqlkit-plain | 5 | 5 | 100% | 4 | 592s | 583s |
+| 01-crud-gqlkit-skill | 5 | 5 | 100% | 5 | 345s | 325s |
+| 02-relation-codegen | 5 | 5 | 100% | 6 | 659s | 673s |
+| 02-relation-pothos | 5 | 5 | 100% | 6 | 373s | 329s |
+| 02-relation-gqlkit-plain | 5 | 5 | 100% | 6 | 466s | 426s |
+| 02-relation-gqlkit-skill | 5 | 5 | 100% | 7 | 387s | 394s |
+
+## (A) Skill consultation (gqlkit-skill variants only)
+
+For each `*-gqlkit-skill` eval we recorded which `.claude/skills/gqlkit-guide/*.md` files the agent read from the bundled skill before producing code.
+
+| eval | runs that read skill | total files read (avg) | top files read |
+|---|---:|---:|---|
+| 01-crud-gqlkit-skill | 5/5 | 6.4 | gqlkit-guide/references/schema/queries-mutations.md (5), gqlkit-guide/references/schema/enums.md (5), gqlkit-guide/references/getting-started.md (5) |
+| 02-relation-gqlkit-skill | 5/5 | 6.6 | gqlkit-guide/references/schema/objects.md (5), gqlkit-guide/references/schema/queries-mutations.md (5), gqlkit-guide/references/getting-started.md (5) |
+
+## Failures
+
+None.
+
+## Per-test pass rate
+
+Each eval ships its own EVAL.ts with task-specific assertions. The number under `tests / run` above is constant per eval; here we show how often the per-test assertions passed.
+
+| eval | per-run pass | failures observed |
+|---|---|---|
+| 01-crud-codegen | 4/4, 4/4, 4/4, 4/4, 4/4 | — |
+| 01-crud-pothos | 4/4, 4/4, 4/4, 4/4, 4/4 | — |
+| 01-crud-gqlkit-plain | 4/4, 4/4, 4/4, 4/4, 4/4 | — |
+| 01-crud-gqlkit-skill | 5/5, 5/5, 5/5, 5/5, 5/5 | — |
+| 02-relation-codegen | 6/6, 6/6, 6/6, 6/6, 6/6 | — |
+| 02-relation-pothos | 6/6, 6/6, 6/6, 6/6, 6/6 | — |
+| 02-relation-gqlkit-plain | 6/6, 6/6, 6/6, 6/6, 6/6 | — |
+| 02-relation-gqlkit-skill | 7/7, 7/7, 7/7, 7/7, 7/7 | — |
+
+## Comparison across setups (mean per task)
+
+Comparing setups within each task. `turns` is `o11y.totalTurns` reported by agent-eval — a rough proxy for how much agent effort the task took.
+
+### 01-crud
+
+| setup | mean dur | mean turns | tests |
+|---|---:|---:|---:|
+| codegen | 610s | 10.6 | 4 |
+| pothos | 407s | 7.4 | 4 |
+| gqlkit-plain | 592s | 11.0 | 4 |
+| gqlkit-skill | 345s | 7.8 | 5 |
+
+### 02-relation
+
+| setup | mean dur | mean turns | tests |
+|---|---:|---:|---:|
+| codegen | 659s | 12.6 | 6 |
+| pothos | 373s | 6.6 | 6 |
+| gqlkit-plain | 466s | 11.2 | 6 |
+| gqlkit-skill | 387s | 7.8 | 7 |
+
+## Observations
+
+- **01-crud, gqlkit + skill vs gqlkit plain**: mean turns 7.8 vs 11.0 (29% fewer with skill); mean duration 345s vs 592s (42% faster).
+- **02-relation, gqlkit + skill vs gqlkit plain**: mean turns 7.8 vs 11.2 (30% fewer with skill); mean duration 387s vs 466s (17% faster).
+- **(B) DataLoader assertions in 02-relation passed in all 15 runs** (5 × {codegen, Pothos, gqlkit-plain, gqlkit-skill}) — the agent reached for `ctx.loaders.*` and avoided the obvious `Promise.all(.find())` N+1 shape *without any prompt-side hint*.
+- **(F) `User.email` exclusion passed in every run** across all 40 — the agent does not leak the sensitive field even though it is in the backing type.
+- **gqlkit-skill agents are fastest** despite having to read the bundled docs first. Skill consultation correlates with fewer turns (no API trial-and-error).
+
+## Agent activity (turns)
+
+| eval | mean turns | median turns |
+|---|---:|---:|
+| 01-crud-codegen | 10.6 | 9 |
+| 01-crud-pothos | 7.4 | 7 |
+| 01-crud-gqlkit-plain | 11.0 | 11 |
+| 01-crud-gqlkit-skill | 7.8 | 7 |
+| 02-relation-codegen | 12.6 | 14 |
+| 02-relation-pothos | 6.6 | 7 |
+| 02-relation-gqlkit-plain | 11.2 | 12 |
+| 02-relation-gqlkit-skill | 7.8 | 8 |

--- a/eval/evals/01-crud-codegen/EVAL.ts
+++ b/eval/evals/01-crud-codegen/EVAL.ts
@@ -1,0 +1,82 @@
+import { execFileSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  buildSchema,
+  type GraphQLObjectType,
+  type GraphQLSchema,
+} from "graphql";
+import { describe, expect, test } from "vitest";
+
+/**
+ * `graphql-codegen` typically generates resolver TS that the agent's resolvers
+ * depend on. Run it before typecheck so the agent doesn't need to keep build
+ * artifacts checked in. The SDL itself is whatever `.graphql` the agent wrote
+ * under `src/`.
+ */
+function loadSchema(): GraphQLSchema {
+  try {
+    execFileSync("pnpm", ["exec", "graphql-codegen"], { stdio: "pipe" });
+  } catch {
+    // No codegen.yml or codegen failure → still try to read SDL files.
+  }
+  const sdl = collectSdl("src");
+  if (sdl.length === 0) {
+    throw new Error(
+      "No *.graphql files found under src/ — agent did not produce SDL",
+    );
+  }
+  return buildSchema(sdl);
+}
+
+function collectSdl(dir: string): string {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) continue;
+    if (entry.name === "node_modules" || entry.name === "dist") continue;
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const inner = collectSdl(p);
+      if (inner) out.push(inner);
+    } else if (entry.isFile() && entry.name.endsWith(".graphql")) {
+      out.push(readFileSync(p, "utf8"));
+    }
+  }
+  return out.join("\n");
+}
+
+describe("01-crud · codegen", () => {
+  test("(C) typecheck passes", () => {
+    expect(() =>
+      execFileSync("npm", ["run", "typecheck"], { stdio: "pipe" }),
+    ).not.toThrow();
+  });
+
+  test("(D-1) schema builds", () => {
+    expect(() => loadSchema()).not.toThrow();
+  });
+
+  test("(D-2) declared operations exist", () => {
+    const schema = loadSchema();
+    const queryFields = schema.getQueryType()?.getFields() ?? {};
+    const mutationFields = schema.getMutationType()?.getFields() ?? {};
+    for (const name of ["users", "user", "posts"]) {
+      expect(Object.keys(queryFields)).toContain(name);
+    }
+    for (const name of [
+      "createUser",
+      "createPost",
+      "updatePost",
+      "deletePost",
+    ]) {
+      expect(Object.keys(mutationFields)).toContain(name);
+    }
+  });
+
+  test("(F) User.email is not exposed", () => {
+    const schema = loadSchema();
+    const User = schema.getType("User") as GraphQLObjectType | null;
+    expect(User, "User type must exist").not.toBeNull();
+    expect(Object.keys(User!.getFields())).not.toContain("email");
+  });
+});

--- a/eval/evals/01-crud-codegen/PROMPT.md
+++ b/eval/evals/01-crud-codegen/PROMPT.md
@@ -1,0 +1,34 @@
+# 01-crud — graphql-codegen
+
+Implement a GraphQL API for a tiny `User` / `Post` system in TypeScript using
+**[graphql-codegen](https://the-guild.dev/graphql/codegen)**.
+
+## Domain
+
+```ts
+// Backing types — already provided in src/db/schema.ts
+type DbUser = { id: string; name: string; email: string; createdAt: Date };
+type DbPost = {
+  id: string; title: string; body: string; authorId: string;
+  internalNotes: string;
+  priority: "low" | "medium" | "high";
+  createdAt: Date;
+};
+```
+
+GraphQL surface:
+
+- `Query.users: [User!]!`
+- `Query.user(id: ID!): User`
+- `Query.posts: [Post!]!`
+- `Mutation.createUser(input: CreateUserInput!): User!`
+- `Mutation.createPost(input: CreatePostInput!): Post!`
+- `Mutation.updatePost(input: UpdatePostInput!): Post!`
+- `Mutation.deletePost(id: ID!): Boolean!`
+
+`src/db/` also exposes a `Context` type used as the GraphQL resolver context.
+
+## Constraints
+
+- **`User.email` MUST NOT be exposed** in the GraphQL schema (sensitive).
+- `Post.internalNotes` is irrelevant — leave it off GraphQL entirely.

--- a/eval/evals/01-crud-codegen/package.json
+++ b/eval/evals/01-crud-codegen/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "eval-01-crud-codegen",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "codegen": "graphql-codegen",
+    "print-schema": "tsx scripts/print-schema.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "graphql": "16.14.0"
+  },
+  "devDependencies": {
+    "@eddeee888/gcg-typescript-resolver-files": "^0.13.0",
+    "@graphql-codegen/cli": "^5.0.0",
+    "@graphql-codegen/typescript": "^4.0.0",
+    "@graphql-codegen/typescript-resolvers": "^4.0.0",
+    "@types/node": "^24.0.0",
+    "tsx": "^4.22.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.6"
+  }
+}

--- a/eval/evals/01-crud-codegen/src/db/db-schema.ts
+++ b/eval/evals/01-crud-codegen/src/db/db-schema.ts
@@ -1,0 +1,49 @@
+/**
+ * Source-of-truth backing schema used across every eval.
+ *
+ * Modeled after a Drizzle ORM schema so agents see a familiar shape.
+ * Each eval's `src/db/schema.ts` is generated from this file via
+ * `pnpm sync` — never edit the copies directly.
+ */
+
+export type DbUser = {
+  id: string;
+  name: string;
+  /** Sensitive: must NEVER appear in the GraphQL schema. */
+  email: string;
+  createdAt: Date;
+};
+
+export type DbPost = {
+  id: string;
+  title: string;
+  body: string;
+  authorId: string;
+  /** Internal moderation notes — must NEVER appear in the GraphQL schema. */
+  internalNotes: string;
+  /** Persisted as a string literal union; expose as a GraphQL enum. */
+  priority: "low" | "medium" | "high";
+  createdAt: Date;
+};
+
+// Approximate Drizzle table objects. They are intentionally untyped against
+// `drizzle-orm` so this fixture installs in the sandbox without pulling drizzle.
+// Treat them as opaque values whose only purpose is to type-check `DbUser` /
+// `DbPost` derivations via the exported types above.
+export const usersTable = {
+  _: "users_table_marker" as const,
+  columns: ["id", "name", "email", "createdAt"] as const,
+};
+
+export const postsTable = {
+  _: "posts_table_marker" as const,
+  columns: [
+    "id",
+    "title",
+    "body",
+    "authorId",
+    "internalNotes",
+    "priority",
+    "createdAt",
+  ] as const,
+};

--- a/eval/evals/01-crud-codegen/src/db/loaders.ts
+++ b/eval/evals/01-crud-codegen/src/db/loaders.ts
@@ -1,0 +1,55 @@
+/**
+ * DataLoader-shaped stubs the agent must wire through GraphQL context.
+ *
+ * The bodies throw so callers can't accidentally pass tests by bypassing
+ * the loader plumbing. EVAL.ts checks the generated resolvers actually
+ * invoke these loaders.
+ */
+
+import type { DbPost, DbUser } from "./db-schema.js";
+
+export interface Loader<K, V> {
+  load(key: K): Promise<V>;
+  loadMany(keys: readonly K[]): Promise<V[]>;
+}
+
+export type UserByIdLoader = Loader<string, DbUser>;
+export type PostsByUserIdLoader = Loader<string, DbPost[]>;
+
+export function createUserByIdLoader(): UserByIdLoader {
+  return {
+    load() {
+      throw new Error(
+        "UserByIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+    loadMany() {
+      throw new Error(
+        "UserByIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+  };
+}
+
+export function createPostsByUserIdLoader(): PostsByUserIdLoader {
+  return {
+    load() {
+      throw new Error(
+        "PostsByUserIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+    loadMany() {
+      throw new Error(
+        "PostsByUserIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+  };
+}
+
+export interface Context {
+  loaders: {
+    userById: UserByIdLoader;
+    postsByUserId: PostsByUserIdLoader;
+  };
+  viewerId: string | null;
+}

--- a/eval/evals/01-crud-codegen/tsconfig.json
+++ b/eval/evals/01-crud-codegen/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "outDir": "dist"
+  },
+  "include": ["src", "scripts"]
+}

--- a/eval/evals/01-crud-gqlkit-plain/EVAL.ts
+++ b/eval/evals/01-crud-gqlkit-plain/EVAL.ts
@@ -1,0 +1,81 @@
+import { execFileSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  buildSchema,
+  type GraphQLObjectType,
+  type GraphQLSchema,
+} from "graphql";
+import { describe, expect, test } from "vitest";
+
+/**
+ * gqlkit emits `src/gqlkit/__generated__/schema.graphql` when `gqlkit gen`
+ * runs. Trigger gen, then collect every SDL file under `src/` (covers the
+ * generated SDL plus anything the agent authored by hand).
+ */
+function loadSchema(): GraphQLSchema {
+  try {
+    execFileSync("pnpm", ["exec", "gqlkit", "gen"], { stdio: "pipe" });
+  } catch {
+    // gqlkit might not be configured — still try to read whatever's there.
+  }
+  const sdl = collectSdl("src");
+  if (sdl.length === 0) {
+    throw new Error(
+      "No *.graphql files found under src/ — did `gqlkit gen` run?",
+    );
+  }
+  return buildSchema(sdl);
+}
+
+function collectSdl(dir: string): string {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) continue;
+    if (entry.name === "node_modules" || entry.name === "dist") continue;
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const inner = collectSdl(p);
+      if (inner) out.push(inner);
+    } else if (entry.isFile() && entry.name.endsWith(".graphql")) {
+      out.push(readFileSync(p, "utf8"));
+    }
+  }
+  return out.join("\n");
+}
+
+describe("01-crud · gqlkit-plain", () => {
+  test("(C) typecheck passes", () => {
+    expect(() =>
+      execFileSync("npm", ["run", "typecheck"], { stdio: "pipe" }),
+    ).not.toThrow();
+  });
+
+  test("(D-1) schema builds", () => {
+    expect(() => loadSchema()).not.toThrow();
+  });
+
+  test("(D-2) declared operations exist", () => {
+    const schema = loadSchema();
+    const queryFields = schema.getQueryType()?.getFields() ?? {};
+    const mutationFields = schema.getMutationType()?.getFields() ?? {};
+    for (const name of ["users", "user", "posts"]) {
+      expect(Object.keys(queryFields)).toContain(name);
+    }
+    for (const name of [
+      "createUser",
+      "createPost",
+      "updatePost",
+      "deletePost",
+    ]) {
+      expect(Object.keys(mutationFields)).toContain(name);
+    }
+  });
+
+  test("(F) User.email is not exposed", () => {
+    const schema = loadSchema();
+    const User = schema.getType("User") as GraphQLObjectType | null;
+    expect(User, "User type must exist").not.toBeNull();
+    expect(Object.keys(User!.getFields())).not.toContain("email");
+  });
+});

--- a/eval/evals/01-crud-gqlkit-plain/PROMPT.md
+++ b/eval/evals/01-crud-gqlkit-plain/PROMPT.md
@@ -1,0 +1,35 @@
+# 01-crud — gqlkit (plain)
+
+Implement a GraphQL API for a tiny `User` / `Post` system in TypeScript using
+**[gqlkit](https://www.npmjs.com/package/@gqlkit-ts/cli)** (`@gqlkit-ts/cli` and
+`@gqlkit-ts/runtime`).
+
+## Domain
+
+```ts
+// Backing types — already provided in src/db/schema.ts
+type DbUser = { id: string; name: string; email: string; createdAt: Date };
+type DbPost = {
+  id: string; title: string; body: string; authorId: string;
+  internalNotes: string;
+  priority: "low" | "medium" | "high";
+  createdAt: Date;
+};
+```
+
+GraphQL surface:
+
+- `Query.users: [User!]!`
+- `Query.user(id: ID!): User`
+- `Query.posts: [Post!]!`
+- `Mutation.createUser(input: CreateUserInput!): User!`
+- `Mutation.createPost(input: CreatePostInput!): Post!`
+- `Mutation.updatePost(input: UpdatePostInput!): Post!`
+- `Mutation.deletePost(id: ID!): Boolean!`
+
+`src/db/` also exposes a `Context` type used as the GraphQL resolver context.
+
+## Constraints
+
+- **`User.email` MUST NOT be exposed** in the GraphQL schema (sensitive).
+- `Post.internalNotes` is irrelevant — leave it off GraphQL entirely.

--- a/eval/evals/01-crud-gqlkit-plain/package.json
+++ b/eval/evals/01-crud-gqlkit-plain/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "eval-01-crud-gqlkit-plain",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "gen": "gqlkit gen",
+    "print-schema": "tsx scripts/print-schema.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@gqlkit-ts/runtime": "^0.3.0",
+    "graphql": "16.14.0"
+  },
+  "devDependencies": {
+    "@gqlkit-ts/cli": "^0.7.2",
+    "@types/node": "^24.0.0",
+    "tsx": "^4.22.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.6"
+  }
+}

--- a/eval/evals/01-crud-gqlkit-plain/src/db/db-schema.ts
+++ b/eval/evals/01-crud-gqlkit-plain/src/db/db-schema.ts
@@ -1,0 +1,49 @@
+/**
+ * Source-of-truth backing schema used across every eval.
+ *
+ * Modeled after a Drizzle ORM schema so agents see a familiar shape.
+ * Each eval's `src/db/schema.ts` is generated from this file via
+ * `pnpm sync` — never edit the copies directly.
+ */
+
+export type DbUser = {
+  id: string;
+  name: string;
+  /** Sensitive: must NEVER appear in the GraphQL schema. */
+  email: string;
+  createdAt: Date;
+};
+
+export type DbPost = {
+  id: string;
+  title: string;
+  body: string;
+  authorId: string;
+  /** Internal moderation notes — must NEVER appear in the GraphQL schema. */
+  internalNotes: string;
+  /** Persisted as a string literal union; expose as a GraphQL enum. */
+  priority: "low" | "medium" | "high";
+  createdAt: Date;
+};
+
+// Approximate Drizzle table objects. They are intentionally untyped against
+// `drizzle-orm` so this fixture installs in the sandbox without pulling drizzle.
+// Treat them as opaque values whose only purpose is to type-check `DbUser` /
+// `DbPost` derivations via the exported types above.
+export const usersTable = {
+  _: "users_table_marker" as const,
+  columns: ["id", "name", "email", "createdAt"] as const,
+};
+
+export const postsTable = {
+  _: "posts_table_marker" as const,
+  columns: [
+    "id",
+    "title",
+    "body",
+    "authorId",
+    "internalNotes",
+    "priority",
+    "createdAt",
+  ] as const,
+};

--- a/eval/evals/01-crud-gqlkit-plain/src/db/loaders.ts
+++ b/eval/evals/01-crud-gqlkit-plain/src/db/loaders.ts
@@ -1,0 +1,55 @@
+/**
+ * DataLoader-shaped stubs the agent must wire through GraphQL context.
+ *
+ * The bodies throw so callers can't accidentally pass tests by bypassing
+ * the loader plumbing. EVAL.ts checks the generated resolvers actually
+ * invoke these loaders.
+ */
+
+import type { DbPost, DbUser } from "./db-schema.js";
+
+export interface Loader<K, V> {
+  load(key: K): Promise<V>;
+  loadMany(keys: readonly K[]): Promise<V[]>;
+}
+
+export type UserByIdLoader = Loader<string, DbUser>;
+export type PostsByUserIdLoader = Loader<string, DbPost[]>;
+
+export function createUserByIdLoader(): UserByIdLoader {
+  return {
+    load() {
+      throw new Error(
+        "UserByIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+    loadMany() {
+      throw new Error(
+        "UserByIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+  };
+}
+
+export function createPostsByUserIdLoader(): PostsByUserIdLoader {
+  return {
+    load() {
+      throw new Error(
+        "PostsByUserIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+    loadMany() {
+      throw new Error(
+        "PostsByUserIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+  };
+}
+
+export interface Context {
+  loaders: {
+    userById: UserByIdLoader;
+    postsByUserId: PostsByUserIdLoader;
+  };
+  viewerId: string | null;
+}

--- a/eval/evals/01-crud-gqlkit-plain/tsconfig.json
+++ b/eval/evals/01-crud-gqlkit-plain/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "outDir": "dist"
+  },
+  "include": ["src", "scripts"]
+}

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/SKILL.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: gqlkit-guide
+description: Use when the user asks about "gqlkit", "gqlkit usage", "gqlkit schema definition", "gqlkit configuration", "gqlkit resolvers", "GraphQL code generation with gqlkit", or needs guidance on gqlkit conventions, type definitions, or integration with GraphQL servers or ORMs.
+---
+
+# gqlkit Guide
+
+gqlkit generates GraphQL schema and resolver maps from TypeScript types and functions.
+
+## How it works
+
+1. Write TypeScript types in `src/gqlkit/schema/` → become GraphQL types
+2. Write resolver functions using `defineQuery`, `defineMutation`, `defineField` → become GraphQL resolvers
+3. Run `gqlkit gen` → outputs `typeDefs` and `resolvers` to `src/gqlkit/__generated__/`
+
+## Design principles
+
+- **Implement first**: Write types and resolvers, generate schema when ready. No edit-regenerate-implement loops.
+- **Just types and functions**: Plain TypeScript with a thin API. No decorators, no complex generics.
+- **Type-safe**: TypeScript types become GraphQL types. Resolver signatures checked at compile time.
+
+## How to Use This Skill
+
+Read [references/index.md](references/index.md) first. It contains the complete documentation index with all available topics.
+
+Navigate to specific documentation files based on user needs as indicated in the index.

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/coding-agents.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/coding-agents.md
@@ -1,0 +1,64 @@
+---
+title: Coding Agents
+description: Set up AI coding agents like Claude Code and Codex to understand gqlkit conventions. (skip if reading via `gqlkit-guide` skill)
+---
+
+# Coding Agents
+
+gqlkit provides built-in support for AI coding agents like [Claude Code](https://claude.ai/code) and [OpenAI Codex](https://openai.com/index/openai-codex/). The `gqlkit docs` command generates skill files that help these tools understand gqlkit conventions and provide better assistance.
+
+## Setup
+
+Run the following command in your project root:
+
+```sh filename="npm"
+npm exec gqlkit docs
+```
+
+```sh filename="pnpm"
+pnpm gqlkit docs
+```
+
+```sh filename="yarn"
+yarn gqlkit docs
+```
+
+The command auto-detects your environment based on existing files (`CLAUDE.md`, `.claude/`, `AGENTS.md`, `.codex/`) and generates the appropriate files.
+
+## Generated Files
+
+### Claude Code
+
+When Claude Code environment is detected (or `--claude` flag is used):
+
+- `.claude/skills/gqlkit-guide/SKILL.md` - Skill definition with gqlkit documentation
+- `.claude/skills/gqlkit-guide/references/` - Symlink to detailed documentation
+- `CLAUDE.md` - Updated with gqlkit section (created if not exists)
+
+### OpenAI Codex
+
+When Codex environment is detected (or `--codex` flag is used):
+
+- `.codex/skills/gqlkit-guide/SKILL.md` - Skill definition with gqlkit documentation
+- `.codex/skills/gqlkit-guide/references/` - Symlink to detailed documentation
+- `AGENTS.md` - Updated with gqlkit section (created if not exists)
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--output <dir>` | Output directory (default: current directory) |
+| `--claude` | Generate Claude Code files explicitly |
+| `--codex` | Generate Codex files explicitly |
+
+## How It Works
+
+The generated skill files follow the [Agent Skills](https://agentskills.io/) specification. When you ask the coding agent about gqlkit, it will:
+
+1. Recognize gqlkit-related questions from the skill description
+2. Read the bundled documentation to understand gqlkit conventions
+3. Provide accurate guidance based on the latest documentation
+
+## Keeping Skills Updated
+
+Re-run `gqlkit docs` after updating gqlkit to ensure the skill files reflect the latest documentation.

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/configuration.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/configuration.md
@@ -1,0 +1,182 @@
+---
+title: Configuration
+description: Configure gqlkit via gqlkit.config.ts in your project root.
+---
+
+# Configuration
+
+gqlkit can be configured via `gqlkit.config.ts` in your project root.
+
+## CLI Options
+
+The `gqlkit gen` command accepts the following options:
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--config <path>` | `-c` | Path to config file (default: `gqlkit.config.ts`) |
+| `--cwd <path>` | | Working directory for code generation |
+
+### Using Multiple Config Files
+
+You can use different config files for different GraphQL schemas:
+
+```sh
+# Generate with default config (gqlkit.config.ts)
+gqlkit gen
+
+# Generate with a specific config file
+gqlkit gen --config gqlkit.public.config.ts
+gqlkit gen -c gqlkit.admin.config.ts
+```
+
+This is useful when you need to generate multiple GraphQL schemas from the same project, such as separate public and internal APIs.
+
+## Basic Configuration
+
+```ts
+// gqlkit.config.ts
+import { defineConfig } from "@gqlkit-ts/cli";
+
+export default defineConfig({
+  // Source directory (default: "src/gqlkit/schema")
+  sourceDir: "src/gqlkit/schema",
+
+  // Glob patterns to exclude from scanning
+  sourceIgnoreGlobs: ["**/*.test.ts"],
+
+  // Custom scalar mappings (config-based approach)
+  scalars: [
+    {
+      name: "DateTime",
+      tsType: { from: "./src/gqlkit/schema/scalars", name: "DateTime" },
+      description: "ISO 8601 datetime",
+    },
+    {
+      name: "UUID",
+      tsType: { name: "string" }, // Global type
+    },
+  ],
+
+  // Output paths
+  output: {
+    typeDefsPath: "src/gqlkit/__generated__/typeDefs.ts",
+    resolversPath: "src/gqlkit/__generated__/resolvers.ts",
+    schemaPath: "src/gqlkit/__generated__/schema.graphql",
+    // Set to null to disable output:
+    // schemaPath: null,
+    // Import extension in generated files (default: "js")
+    // importExtension: "none", // for bundlers
+  },
+
+  // Hooks
+  hooks: {
+    // Run after all files are written (e.g., formatting)
+    afterAllFileWrite: "prettier --write",
+    // Or multiple commands:
+    // afterAllFileWrite: ["prettier --write", "eslint --fix"],
+  },
+});
+```
+
+## Custom Scalar Types
+
+Map TypeScript types to GraphQL custom scalars via config. See [Scalars](./schema/scalars) for complete documentation including the `GqlScalar` approach.
+
+```ts
+export default defineConfig({
+  scalars: [
+    {
+      name: "DateTime",
+      tsType: { from: "./src/gqlkit/schema/scalars", name: "DateTime" },
+      description: "ISO 8601 datetime string",
+    },
+  ],
+});
+```
+
+## Output Paths
+
+Customize output file locations or disable specific outputs:
+
+```ts
+export default defineConfig({
+  output: {
+    typeDefsPath: "generated/schema.ts", // Custom path
+    resolversPath: "generated/resolvers.ts",
+    schemaPath: null, // Disable SDL output
+  },
+});
+```
+
+### Output Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `typeDefsPath` | `string` \| `null` | `"src/gqlkit/__generated__/typeDefs.ts"` | Path for the TypeDefs output |
+| `resolversPath` | `string` \| `null` | `"src/gqlkit/__generated__/resolvers.ts"` | Path for the resolvers output |
+| `schemaPath` | `string` \| `null` | `"src/gqlkit/__generated__/schema.graphql"` | Path for the SDL output |
+| `importExtension` | `"js"` \| `"none"` \| `"ts"` | `"js"` | File extension for import statements |
+
+Set any path to `null` to disable that output.
+
+The `importExtension` option controls file extensions in generated import statements:
+
+- `"js"` (default): Converts `.ts` to `.js` (compatible with ESM + Node16)
+- `"none"`: No extension (for bundlers like webpack, vite)
+- `"ts"`: Keeps `.ts` extension (for Deno)
+
+## Hooks
+
+Execute commands after file generation:
+
+```ts
+export default defineConfig({
+  hooks: {
+    // Single command
+    afterAllFileWrite: "prettier --write",
+  },
+});
+```
+
+You can also specify multiple commands to run sequentially:
+
+```ts
+export default defineConfig({
+  hooks: {
+    // Multiple commands (executed sequentially)
+    afterAllFileWrite: ["prettier --write", "eslint --fix"],
+  },
+});
+```
+
+### Available Hooks
+
+| Hook | Description |
+|------|-------------|
+| `afterAllFileWrite` | Runs after all generated files are written. Receives the list of written file paths. |
+
+## Source Directory
+
+By default, gqlkit scans `src/gqlkit/schema` for types and resolvers.
+
+```ts
+export default defineConfig({
+  sourceDir: "src/graphql/schema", // Custom source directory
+});
+```
+
+All TypeScript files (`.ts`, `.cts`, `.mts`) under this directory are scanned.
+
+## Ignore Patterns
+
+Exclude files from scanning using glob patterns:
+
+```ts
+export default defineConfig({
+  sourceIgnoreGlobs: [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/testdata/**",
+  ],
+});
+```

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/getting-started.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/getting-started.md
@@ -1,0 +1,120 @@
+---
+title: Getting Started
+description: Install gqlkit and create your first GraphQL schema from TypeScript.
+---
+
+# Getting Started
+
+## Installation
+
+```sh filename="npm"
+npm install @gqlkit-ts/runtime @graphql-tools/schema graphql
+npm install -D @gqlkit-ts/cli
+```
+
+```sh filename="pnpm"
+pnpm add @gqlkit-ts/runtime @graphql-tools/schema graphql
+pnpm add -D @gqlkit-ts/cli
+```
+
+```sh filename="yarn"
+yarn add @gqlkit-ts/runtime @graphql-tools/schema graphql
+yarn add -D @gqlkit-ts/cli
+```
+
+> [!TIP]
+>
+> If you use AI coding agents like Claude Code or Codex, run `gqlkit docs` to set up gqlkit skills. See [Coding Agents](./coding-agents) for details.
+
+## Project Structure
+
+gqlkit expects your types and resolvers to be in `src/gqlkit/schema/`:
+
+```
+src/
+└── gqlkit/
+    ├── context.ts       # Context type definition
+    ├── gqlkit.ts        # Resolver factories
+    └── schema/
+        ├── user.ts      # User type and resolvers
+        ├── post.ts      # Post type and resolvers
+        └── query.ts     # Query resolvers
+```
+
+## Set Up Context and Resolver Factories
+
+Create `src/gqlkit/context.ts` to define your context type:
+
+```typescript
+export type Context = {
+  currentUser: { id: string; name: string; email: string | null } | null;
+};
+```
+
+Create `src/gqlkit/gqlkit.ts` to export resolver factories:
+
+```typescript
+import { createGqlkitApis } from "@gqlkit-ts/runtime";
+import type { Context } from "./context";
+
+export const { defineQuery, defineMutation, defineField } =
+  createGqlkitApis<Context>();
+```
+
+## Define Your First Type and Query
+
+Create a simple User type and query in `src/gqlkit/schema/user.ts`:
+
+```typescript
+import { defineQuery } from "../gqlkit";
+import type { NoArgs } from "@gqlkit-ts/runtime";
+
+export type User = {
+  id: string;
+  name: string;
+  email: string | null;
+};
+
+// NoArgs indicates this query takes no arguments
+export const me = defineQuery<NoArgs, User | null>(
+  (_root, _args, ctx) => ctx.currentUser
+);
+```
+
+## Generate Schema
+
+Run the generator:
+
+```sh filename="npm"
+npm exec gqlkit gen
+```
+
+```sh filename="pnpm"
+pnpm gqlkit gen
+```
+
+```sh filename="yarn"
+yarn gqlkit gen
+```
+
+This will create files in `src/gqlkit/__generated__/`:
+- `schema.ts` - GraphQL schema AST (DocumentNode)
+- `resolvers.ts` - Resolver map
+
+## Create GraphQL Schema
+
+Use `@graphql-tools/schema` to combine the generated outputs into an executable schema:
+
+```typescript
+import { makeExecutableSchema } from "@graphql-tools/schema";
+import { typeDefs } from "./gqlkit/__generated__/schema";
+import { resolvers } from "./gqlkit/__generated__/resolvers";
+
+export const schema = makeExecutableSchema({ typeDefs, resolvers });
+```
+
+## Next Steps
+
+- [HTTP Server Integration](./integration/yoga) - Connect your schema to graphql-yoga, Apollo Server, or other HTTP servers
+- [Object Types](./schema/objects) - Learn more about defining types
+- [Queries & Mutations](./schema/queries-mutations) - Advanced resolver patterns

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/index.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/index.md
@@ -1,0 +1,47 @@
+# gqlkit
+
+gqlkit generates GraphQL schema and resolver maps from TypeScript types and functions.
+
+## How it works
+
+1. Write TypeScript types in `src/gqlkit/schema/` → become GraphQL types
+2. Write resolver functions using `defineQuery`, `defineMutation`, `defineField` → become GraphQL resolvers
+3. Run `gqlkit gen` → outputs `typeDefs` and `resolvers` to `src/gqlkit/__generated__/`
+
+## Design principles
+
+- **Implement first**: Write types and resolvers, generate schema when ready. No edit-regenerate-implement loops.
+- **Just types and functions**: Plain TypeScript with a thin API. No decorators, no complex generics.
+- **Type-safe**: TypeScript types become GraphQL types. Resolver signatures checked at compile time.
+
+## Documentation
+
+- [What is gqlkit?](./what-is-gqlkit.md): Just types and functions — write TypeScript, generate GraphQL.
+- [Getting Started](./getting-started.md): Install gqlkit and create your first GraphQL schema from TypeScript.
+
+## Schema Definition
+
+- [Schema Definition](./schema/conventions.md): gqlkit generates GraphQL schema from your TypeScript types.
+- [Defining Object Types](./schema/objects.md): Plain TypeScript type exports become GraphQL Object types.
+- [Defining Input Types](./schema/inputs.md): TypeScript types with Input suffix are treated as GraphQL input types.
+- [Defining Queries and Mutations](./schema/queries-mutations.md): Define Query and Mutation fields using the @gqlkit-ts/runtime API.
+- [Defining Field Resolvers](./schema/fields.md): Add computed fields to object types using defineField.
+- [Defining Scalar Types](./schema/scalars.md): gqlkit provides built-in scalar types and supports custom scalar definitions.
+- [Defining Enum Types](./schema/enums.md): gqlkit converts TypeScript string literal unions and enums to GraphQL enum types.
+- [Defining Union Types](./schema/unions.md): TypeScript union types of object types are converted to GraphQL union types.
+- [Defining Interface Types](./schema/interfaces.md): Define GraphQL interface types using the GqlInterface utility type.
+- [Resolving Abstract Types](./schema/abstract-resolvers.md): Handle runtime type resolution for GraphQL unions and interfaces.
+- [Adding Documentation to Schema](./schema/documentation.md): gqlkit extracts TSDoc/JSDoc comments and converts them to GraphQL descriptions.
+- [Defining Custom Directives](./schema/directives.md): Define custom directives using the GqlDirective utility type.
+
+## Integration
+
+- [Integration with graphql-yoga](./integration/yoga.md): Use gqlkit with graphql-yoga, a batteries-included GraphQL server.
+- [Integration with Apollo Server](./integration/apollo.md): Use gqlkit with Apollo Server, a popular GraphQL server.
+- [Integration with Drizzle ORM](./integration/drizzle.md): Derive GraphQL types from Drizzle table definitions.
+- [Integration with Prisma](./integration/prisma.md): Derive GraphQL types from Prisma model types.
+
+## Guides
+
+- [Configuration](./configuration.md): Configure gqlkit via gqlkit.config.ts in your project root.
+- [Coding Agents](./coding-agents.md): Set up AI coding agents like Claude Code and Codex to understand gqlkit conventions. (skip if reading via `gqlkit-guide` skill)

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/integration/apollo.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/integration/apollo.md
@@ -1,0 +1,77 @@
+---
+title: Integration with Apollo Server
+description: Use gqlkit with Apollo Server, a popular GraphQL server.
+---
+
+# Apollo Server
+
+[Apollo Server](https://www.apollographql.com/docs/apollo-server/) is a popular GraphQL server with extensive features and ecosystem.
+
+## Installation
+
+```sh filename="npm"
+npm install @apollo/server
+```
+
+```sh filename="pnpm"
+pnpm add @apollo/server
+```
+
+```sh filename="yarn"
+yarn add @apollo/server
+```
+
+## Prerequisites
+
+Create an executable schema following the [Getting Started guide](../getting-started.md#create-graphql-schema).
+
+## Basic Server
+
+Using the standalone server:
+
+```typescript
+// src/server.ts
+import { ApolloServer } from "@apollo/server";
+import { startStandaloneServer } from "@apollo/server/standalone";
+import { schema } from "./schema";
+
+const server = new ApolloServer({ schema });
+
+const { url } = await startStandaloneServer(server, {
+  listen: { port: 4000 },
+});
+
+console.log(`Server is running on ${url}`);
+```
+
+## With Context
+
+If your resolvers use a context type, first [set up context and resolver factories](../getting-started.md#set-up-context-and-resolver-factories), then provide a context factory to your server:
+
+```typescript
+// src/server.ts
+import { ApolloServer } from "@apollo/server";
+import { startStandaloneServer } from "@apollo/server/standalone";
+import { schema } from "./schema";
+import type { Context } from "./gqlkit/context";
+
+const server = new ApolloServer<Context>({ schema });
+
+const { url } = await startStandaloneServer(server, {
+  listen: { port: 4000 },
+  context: async ({ req }) => {
+    const user = await getUserFromRequest(req);
+    return {
+      currentUser: user,
+      db: database,
+    };
+  },
+});
+
+console.log(`Server is running on ${url}`);
+```
+
+## Further Reading
+
+- [Apollo Server Documentation](https://www.apollographql.com/docs/apollo-server/)
+- [Apollo Server Plugins](https://www.apollographql.com/docs/apollo-server/builtin-plugins)

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/integration/drizzle.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/integration/drizzle.md
@@ -1,0 +1,187 @@
+---
+title: Integration with Drizzle ORM
+description: Derive GraphQL types from Drizzle table definitions.
+---
+
+# Drizzle ORM
+
+[Drizzle ORM](https://orm.drizzle.team/) is a TypeScript ORM with type-safe schema definitions. gqlkit integrates seamlessly with Drizzle by using `InferSelectModel` and `InferInsertModel` to derive GraphQL types from your table definitions.
+
+## Installation
+
+```sh filename="npm"
+npm install drizzle-orm postgres
+```
+
+```sh filename="pnpm"
+pnpm add drizzle-orm postgres
+```
+
+```sh filename="yarn"
+yarn add drizzle-orm postgres
+```
+
+## Defining Tables
+
+Define your database tables with Drizzle:
+
+```typescript
+// src/db/schema.ts
+import { pgEnum, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+
+export const userStatusEnum = pgEnum("user_status", [
+  "active",
+  "inactive",
+  "suspended",
+]);
+
+export const users = pgTable("users", {
+  id: uuid().primaryKey().defaultRandom(),
+  name: text().notNull(),
+  email: text().notNull().unique(),
+  status: userStatusEnum().notNull().default("active"),
+  createdAt: timestamp().notNull().defaultNow(),
+});
+
+export const posts = pgTable("posts", {
+  id: uuid().primaryKey().defaultRandom(),
+  title: text().notNull(),
+  content: text(),
+  priority: text({ enum: ["low", "medium", "high"] }).notNull().default("medium"),
+  authorId: uuid()
+    .notNull()
+    .references(() => users.id),
+  createdAt: timestamp().notNull().defaultNow(),
+});
+```
+
+Both `pgEnum()` and `text({ enum: [...] })` are supported for defining enum columns. gqlkit automatically generates corresponding GraphQL enum types from these definitions.
+
+## Defining Custom Scalars
+
+Define custom scalar types using `GqlScalar` for fields like timestamps:
+
+```typescript
+// src/gqlkit/schema/scalars.ts
+import type { GqlScalar } from "@gqlkit-ts/runtime";
+
+export type DateTime = GqlScalar<"DateTime", Date>;
+```
+
+## Exporting GraphQL Types
+
+Use Drizzle's type inference utilities to export GraphQL types from your table definitions:
+
+```typescript
+// src/gqlkit/schema/user.ts
+import type { InferSelectModel } from "drizzle-orm";
+import { users as usersTable } from "../../db/schema.js";
+
+// Export as GraphQL object type
+export type User = InferSelectModel<typeof usersTable>;
+```
+
+This generates the following GraphQL schema:
+
+```graphql
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+  SUSPENDED
+}
+
+type User {
+  id: String!
+  name: String!
+  email: String!
+  status: UserStatus!
+  createdAt: DateTime!
+}
+```
+
+## Defining Resolvers
+
+Define resolvers that use the derived types:
+
+```typescript
+// src/gqlkit/schema/user.ts
+import type { NoArgs } from "@gqlkit-ts/runtime";
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { eq } from "drizzle-orm";
+import { posts as postsTable, users as usersTable } from "../../db/schema.js";
+import { defineField, defineMutation, defineQuery } from "../gqlkit.js";
+import type { Post } from "./post.js";
+
+export type User = InferSelectModel<typeof usersTable>;
+
+export const allUsers = defineQuery<NoArgs, User[]>(
+  async (_root, _args, ctx) => {
+    return ctx.db.select().from(usersTable);
+  },
+);
+
+export const user = defineQuery<{ id: string }, User | null>(
+  async (_root, args, ctx) => {
+    const result = await ctx.db
+      .select()
+      .from(usersTable)
+      .where(eq(usersTable.id, args.id));
+    return result[0] ?? null;
+  },
+);
+
+export const createUser = defineMutation<
+  { input: Omit<InferInsertModel<typeof usersTable>, "id" | "createdAt"> },
+  User
+>(async (_root, args, ctx) => {
+  const result = await ctx.db.insert(usersTable).values(args.input).returning();
+  return result[0]!;
+});
+
+export const posts = defineField<User, NoArgs, Post[]>(
+  async (parent, _args, ctx) => {
+    return ctx.db
+      .select()
+      .from(postsTable)
+      .where(eq(postsTable.authorId, parent.id));
+  },
+);
+```
+
+## Context with Database
+
+Set up the context type to include your database instance. For basic setup, see [Set Up Context and Resolver Factories](../getting-started.md#set-up-context-and-resolver-factories).
+
+```typescript
+// src/db/db.ts
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import * as schema from "./schema.js";
+
+const client = postgres(process.env.DATABASE_URL!);
+export const db = drizzle(client, { schema, casing: "snake_case" });
+export type Database = typeof db;
+```
+
+```typescript
+// src/gqlkit/context.ts
+import type { Database } from "../db/db.js";
+
+export type Context = {
+  db: Database;
+};
+```
+
+## Complete Example
+
+See the [examples/with-drizzle](https://github.com/gqlkit/gqlkit/tree/main/examples/with-drizzle) directory for a complete working example with:
+
+- PostgreSQL tables with DateTime scalar
+- Enum types using both `pgEnum()` and `text({ enum: [...] })`
+- User and Post types with relationships
+- Query, Mutation, and Field resolvers
+
+## Further Reading
+
+- [Drizzle ORM Documentation](https://orm.drizzle.team/docs/overview)
+- [Drizzle with PostgreSQL](https://orm.drizzle.team/docs/get-started/postgresql-new)

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/integration/prisma.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/integration/prisma.md
@@ -1,0 +1,196 @@
+---
+title: Integration with Prisma
+description: Derive GraphQL types from Prisma model types.
+---
+
+# Prisma
+
+[Prisma](https://www.prisma.io/) is a next-generation ORM for Node.js and TypeScript. gqlkit integrates seamlessly with Prisma by using its generated model types to derive GraphQL types from your schema definitions.
+
+## Installation
+
+```sh filename="npm"
+npm install prisma @prisma/client
+```
+
+```sh filename="pnpm"
+pnpm add prisma @prisma/client
+```
+
+```sh filename="yarn"
+yarn add prisma @prisma/client
+```
+
+## Defining the Schema
+
+Define your database schema in `prisma/schema.prisma`:
+
+```prisma
+// prisma/schema.prisma
+generator client {
+  provider = "prisma-client"
+  output   = "../src/__generated__/prisma"
+}
+
+datasource db {
+  provider = "sqlite"
+}
+
+enum UserStatus {
+  active
+  inactive
+  suspended
+}
+
+model User {
+  id        String     @id @default(uuid())
+  name      String
+  email     String     @unique
+  status    UserStatus @default(active)
+  createdAt DateTime   @default(now()) @map("created_at")
+  posts     Post[]
+
+  @@map("users")
+}
+
+enum PostPriority {
+  low
+  medium
+  high
+}
+
+model Post {
+  id        String       @id @default(uuid())
+  title     String
+  content   String?
+  priority  PostPriority @default(medium)
+  authorId  String       @map("author_id")
+  createdAt DateTime     @default(now()) @map("created_at")
+  author    User         @relation(fields: [authorId], references: [id])
+
+  @@map("posts")
+}
+```
+
+Enum types defined in the Prisma schema are automatically converted to corresponding GraphQL enum types by gqlkit.
+
+## Defining Custom Scalars
+
+Define custom scalar types using `GqlScalar` for fields like timestamps:
+
+```typescript
+// src/gqlkit/schema/scalars.ts
+import type { GqlScalar } from "@gqlkit-ts/runtime";
+
+export type DateTime = GqlScalar<"DateTime", Date>;
+```
+
+## Exporting GraphQL Types
+
+Use Prisma's generated model types to export GraphQL types from your schema definitions:
+
+```typescript
+// src/gqlkit/schema/user.ts
+import type { Prisma } from "../../__generated__/prisma/client.js";
+
+// Export as GraphQL object type
+export type User = Prisma.UserModel;
+```
+
+This generates the following GraphQL schema:
+
+```graphql
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+  SUSPENDED
+}
+
+type User {
+  id: String!
+  name: String!
+  email: String!
+  status: UserStatus!
+  createdAt: DateTime!
+}
+```
+
+## Defining Resolvers
+
+Define resolvers that use the derived types:
+
+```typescript
+// src/gqlkit/schema/user.ts
+import type { NoArgs } from "@gqlkit-ts/runtime";
+import type { Prisma } from "../../__generated__/prisma/client.js";
+import { defineField, defineMutation, defineQuery } from "../gqlkit.js";
+import type { Post } from "./post.js";
+
+export type User = Prisma.UserModel;
+
+export const allUsers = defineQuery<NoArgs, User[]>(
+  async (_root, _args, ctx) => {
+    return ctx.db.user.findMany();
+  },
+);
+
+export const user = defineQuery<{ id: string }, User | null>(
+  async (_root, args, ctx) => {
+    return ctx.db.user.findUnique({
+      where: { id: args.id },
+    });
+  },
+);
+
+export const createUser = defineMutation<
+  { input: Omit<Prisma.UserCreateInput, "id" | "createdAt" | "posts"> },
+  User
+>(async (_root, args, ctx) => {
+  return ctx.db.user.create({
+    data: args.input,
+  });
+});
+
+export const posts = defineField<User, NoArgs, Post[]>(
+  async (parent, _args, ctx) => {
+    return ctx.db.post.findMany({
+      where: { authorId: parent.id },
+    });
+  },
+);
+```
+
+## Context with Database
+
+Set up the context type to include your Prisma client instance. For basic setup, see [Set Up Context and Resolver Factories](../getting-started.md#set-up-context-and-resolver-factories).
+
+```typescript
+// src/db/db.ts
+import { PrismaClient } from "../__generated__/prisma/client.js";
+
+export const prisma = new PrismaClient();
+export type PrismaDatabase = typeof prisma;
+```
+
+```typescript
+// src/gqlkit/context.ts
+import type { PrismaDatabase } from "../db/db.js";
+
+export type Context = {
+  db: PrismaDatabase;
+};
+```
+
+## Complete Example
+
+See the [examples/with-prisma](https://github.com/gqlkit/gqlkit/tree/main/examples/with-prisma) directory for a complete working example with:
+
+- SQLite database with DateTime scalar
+- Enum types (`UserStatus`, `PostPriority`)
+- User and Post types with relationships
+- Query, Mutation, and Field resolvers
+
+## Further Reading
+
+- [Prisma Documentation](https://www.prisma.io/docs)
+- [Prisma Client API Reference](https://www.prisma.io/docs/orm/reference/prisma-client-reference)

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/integration/yoga.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/integration/yoga.md
@@ -1,0 +1,76 @@
+---
+title: Integration with graphql-yoga
+description: Use gqlkit with graphql-yoga, a batteries-included GraphQL server.
+---
+
+# graphql-yoga
+
+[graphql-yoga](https://the-guild.dev/graphql/yoga-server) is a batteries-included GraphQL server that works in any JavaScript runtime.
+
+## Installation
+
+```sh filename="npm"
+npm install graphql-yoga
+```
+
+```sh filename="pnpm"
+pnpm add graphql-yoga
+```
+
+```sh filename="yarn"
+yarn add graphql-yoga
+```
+
+## Prerequisites
+
+Create an executable schema following the [Getting Started guide](../getting-started.md#create-graphql-schema).
+
+## Basic Server
+
+```typescript
+// src/server.ts
+import { createServer } from "node:http";
+import { createYoga } from "graphql-yoga";
+import { schema } from "./schema";
+
+const yoga = createYoga({ schema });
+const server = createServer(yoga);
+
+server.listen(4000, () => {
+  console.log("Server is running on http://localhost:4000/graphql");
+});
+```
+
+## With Context
+
+If your resolvers use a context type, first [set up context and resolver factories](../getting-started.md#set-up-context-and-resolver-factories), then provide a context factory to your server:
+
+```typescript
+// src/server.ts
+import { createServer } from "node:http";
+import { createYoga } from "graphql-yoga";
+import { schema } from "./schema";
+import type { Context } from "./gqlkit/context";
+
+const yoga = createYoga<{}, Context>({
+  schema,
+  context: async ({ request }) => {
+    const user = await getUserFromRequest(request);
+    return {
+      currentUser: user,
+      db: database,
+    };
+  },
+});
+
+const server = createServer(yoga);
+
+server.listen(4000, () => {
+  console.log("Server is running on http://localhost:4000/graphql");
+});
+```
+
+## Further Reading
+
+- [graphql-yoga Documentation](https://the-guild.dev/graphql/yoga-server/docs)
+- [Envelop Plugins](https://the-guild.dev/graphql/envelop/plugins)

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/abstract-resolvers.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/abstract-resolvers.md
@@ -1,0 +1,263 @@
+---
+title: Resolving Abstract Types
+description: Handle runtime type resolution for GraphQL unions and interfaces.
+---
+
+# Abstract Type Resolution
+
+GraphQL abstract types (unions and interfaces) require runtime type resolution to determine the concrete type of returned values. gqlkit provides `defineResolveType` and `defineIsTypeOf` to handle this.
+
+## Overview
+
+When a GraphQL query returns an abstract type, the server needs to determine which concrete type to use. There are two approaches:
+
+| Approach | Defined On | Returns | Use Case |
+|----------|------------|---------|----------|
+| `resolveType` | Abstract type (union/interface) | Type name string | Single resolver decides the type |
+| `isTypeOf` | Object type | Boolean | Each type checks if value matches |
+
+## Automatic resolveType Generation
+
+When Union or Interface member types have `__typename` or `$typeName` fields with string literal values, gqlkit automatically generates the `resolveType` function. No manual definition is needed.
+
+### Basic Example
+
+```typescript
+export interface User {
+  __typename: "User";
+  id: string;
+  name: string;
+}
+
+export interface Post {
+  __typename: "Post";
+  id: string;
+  title: string;
+}
+
+export type SearchResult = User | Post;
+// resolveType is automatically generated: (obj) => obj.__typename
+```
+
+### Using `$typeName`
+
+If you prefer not to use `__typename` (e.g., to avoid conflicts with GraphQL introspection), you can use `$typeName` instead:
+
+```typescript
+export interface User {
+  $typeName: "User";
+  id: string;
+  name: string;
+}
+
+export interface Post {
+  $typeName: "Post";
+  id: string;
+  title: string;
+}
+
+export type SearchResult = User | Post;
+// resolveType is automatically generated: (obj) => obj.$typeName
+```
+
+### Priority Rules
+
+When both `__typename` and `$typeName` are present, `__typename` takes priority:
+
+```typescript
+export interface User {
+  __typename: "User";  // This value is used
+  $typeName: "UserType";
+  id: string;
+}
+```
+
+### Mixed Patterns
+
+When some members use `__typename` and others use `$typeName`, gqlkit generates a fallback pattern:
+
+```typescript
+export interface User {
+  __typename: "User";
+  id: string;
+}
+
+export interface Post {
+  $typeName: "Post";
+  id: string;
+}
+
+export type SearchResult = User | Post;
+// resolveType: (obj) => obj.__typename ?? obj.$typeName
+```
+
+### Requirements
+
+For automatic generation, the typename field must be:
+
+- Named `__typename` or `$typeName`
+- A **non-optional** field
+- A **non-nullable** type
+- A **string literal** type (not `string`)
+
+```typescript
+// ✅ OK: Valid typename fields
+interface Valid {
+  __typename: "TypeA";       // string literal, required
+}
+
+// ❌ Error: These will not trigger auto-generation
+interface Invalid1 {
+  __typename?: "TypeA";      // optional field
+}
+
+interface Invalid2 {
+  __typename: "TypeA" | null; // nullable type
+}
+
+interface Invalid3 {
+  __typename: string;        // not a string literal
+}
+```
+
+### When to Use Manual defineResolveType
+
+Use `defineResolveType` manually when:
+
+- Your types don't have `__typename` or `$typeName` fields
+- You need custom resolution logic (e.g., checking other properties)
+- You want to override the automatic generation
+
+## Using resolveType
+
+Define a `resolveType` resolver on a union or interface type to determine the concrete type.
+
+### Union Example
+
+```typescript
+import { defineResolveType } from "../gqlkit";
+
+export interface User {
+  id: string;
+  name: string;
+}
+
+export interface Post {
+  id: string;
+  title: string;
+}
+
+export type SearchResult = User | Post;
+
+export const searchResultResolveType = defineResolveType<SearchResult>(
+  (value) => {
+    if ("name" in value) {
+      return "User";
+    }
+    return "Post";
+  }
+);
+```
+
+### Interface Example
+
+```typescript
+import { defineResolveType } from "../gqlkit";
+import { type GqlInterface, type IDString } from "@gqlkit-ts/runtime";
+
+export type Node = GqlInterface<{
+  id: IDString;
+}>;
+
+export const nodeResolveType = defineResolveType<Node>((value) => {
+  if ("name" in value) {
+    return "User";
+  }
+  if ("title" in value) {
+    return "Post";
+  }
+  throw new Error("Unknown Node type");
+});
+```
+
+### Resolver Function Signature
+
+```typescript
+(value: TAbstract, context: TContext, info: GraphQLResolveInfo) => string | Promise<string>
+```
+
+| Argument | Description |
+|----------|-------------|
+| `value` | The resolved value to determine the type of |
+| `context` | The context object |
+| `info` | GraphQL resolve info |
+
+### Type Parameters
+
+`defineResolveType<TAbstract>`:
+
+| Parameter | Description |
+|-----------|-------------|
+| `TAbstract` | The abstract type (union or interface) to resolve |
+
+## Using isTypeOf
+
+Define an `isTypeOf` resolver on an object type to check if a value is of that type.
+
+### Basic Usage
+
+```typescript
+import { defineIsTypeOf } from "../gqlkit";
+
+export interface Dog {
+  kind: string;
+  name: string;
+  breed: string;
+}
+
+export interface Cat {
+  kind: string;
+  name: string;
+  indoor: boolean;
+}
+
+export type Animal = Dog | Cat;
+
+export const dogIsTypeOf = defineIsTypeOf<Dog>((value) => {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "kind" in value &&
+    value.kind === "dog"
+  );
+});
+
+export const catIsTypeOf = defineIsTypeOf<Cat>((value) => {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "kind" in value &&
+    value.kind === "cat"
+  );
+});
+```
+
+### Resolver Function Signature
+
+```typescript
+(value: unknown, context: TContext, info: GraphQLResolveInfo) => boolean | Promise<boolean>
+```
+
+| Argument | Description |
+|----------|-------------|
+| `value` | The value to check (typed as `unknown`) |
+| `context` | The context object |
+| `info` | GraphQL resolve info |
+
+### Type Parameters
+
+`defineIsTypeOf<TObject>`:
+
+| Parameter | Description |
+|-----------|-------------|
+| `TObject` | The object type to check against |

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/conventions.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/conventions.md
@@ -1,0 +1,59 @@
+---
+title: Schema Definition
+description: gqlkit generates GraphQL schema from your TypeScript types.
+---
+
+# Schema Definition
+
+gqlkit generates GraphQL schema from your TypeScript types. All exported types from `src/gqlkit/schema/` are automatically scanned and converted to GraphQL types.
+
+## Type Mapping
+
+gqlkit maps TypeScript types to GraphQL types as follows:
+
+| TypeScript | GraphQL |
+|------------|---------|
+| `string` | `String!` |
+| `number` | `Float!` |
+| `boolean` | `Boolean!` |
+| `IDString`, `IDNumber` | `ID!` |
+| `Int` (branded) | `Int!` |
+| `Float` (branded) | `Float!` |
+| `T \| null` | `T` (nullable) |
+| `T[]` | `[T!]!` |
+| String literal union | Enum type |
+| TypeScript `enum` | Enum type |
+| Union of object types | Union type |
+| `*Input` suffix types | Input Object type |
+| Union with `*Input` suffix | `@oneOf` input object |
+| `GqlInterface<T>` | Interface type |
+| `GqlScalar<Name, Base>` | Custom scalar |
+| `NoArgs` | Indicates resolver takes no arguments |
+
+## Naming Conventions
+
+gqlkit generates type names using predictable conventions:
+
+| Context | Pattern | Example |
+|---------|---------|---------|
+| Object field (inline) | `{ParentType}{Field}` | `User.profile` → `UserProfile` |
+| Input field (inline) | `{ParentWithoutInput}{Field}Input` | `CreateUserInput.address` → `CreateUserAddressInput` |
+| Query/Mutation arg | `{Resolver}{Arg}Input` | `searchUsers(filter)` → `SearchUsersFilterInput` |
+| Field resolver arg | `{Parent}{Field}{Arg}Input` | `User.posts(filter)` → `UserPostsFilterInput` |
+| Inline enum | Same as parent context | `User.status` → `UserStatus` |
+| Payload type | `{Resolver}Payload` | `updateUser` → `UpdateUserPayload` |
+
+For complete details on inline enum naming, see [Inline Enums](./enums.md#inline-enums).
+
+## Project Layout
+
+Default project layout:
+
+```
+src/
+  gqlkit/
+    schema/        # Types and resolvers co-located
+    __generated__/ # Generated files (auto-created)
+```
+
+All TypeScript files (`.ts`, `.cts`, `.mts`) under `src/gqlkit/schema/` are scanned for types and resolvers.

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/directives.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/directives.md
@@ -1,0 +1,201 @@
+---
+title: Defining Custom Directives
+description: Define custom directives using the GqlDirective utility type.
+---
+
+# Custom Directives
+
+Define custom directives using the `GqlDirective` utility type and attach them using `GqlField` or `GqlObject`.
+
+## Defining Directives
+
+```typescript
+// src/gqlkit/schema/directives.ts
+import { type GqlDirective } from "@gqlkit-ts/runtime";
+
+export type Role = "USER" | "ADMIN";
+
+// Directive with typed arguments
+export type AuthDirective<TArgs extends { role: Role[] }> = GqlDirective<
+  "auth",
+  TArgs,
+  "FIELD_DEFINITION"
+>;
+
+// Directive with multiple locations
+export type CacheDirective<TArgs extends { maxAge: number }> = GqlDirective<
+  "cache",
+  TArgs,
+  ["FIELD_DEFINITION", "OBJECT"]
+>;
+```
+
+Generates:
+
+```graphql
+directive @auth(role: [Role!]!) on FIELD_DEFINITION
+directive @cache(maxAge: Float!) on FIELD_DEFINITION | OBJECT
+```
+
+## GqlDirective Type Parameters
+
+`GqlDirective<Name, Args, Location>`:
+
+| Parameter | Description |
+|-----------|-------------|
+| `Name` | The directive name (without `@`) |
+| `Args` | The directive arguments type |
+| `Location` | Where the directive can be used (single or array) |
+
+### Directive Locations
+
+Common directive locations:
+
+| Location | Description |
+|----------|-------------|
+| `FIELD_DEFINITION` | Object type fields |
+| `OBJECT` | Object types |
+| `INPUT_FIELD_DEFINITION` | Input type fields |
+| `ARGUMENT_DEFINITION` | Field arguments |
+| `ENUM_VALUE` | Enum values |
+| `INTERFACE` | Interface types |
+
+## Attaching Directives to Fields
+
+Use `GqlField` to attach directives to object type fields:
+
+```typescript
+import { type GqlField, type IDString } from "@gqlkit-ts/runtime";
+import { type AuthDirective } from "./directives.js";
+
+export type User = {
+  id: IDString;
+  name: string;
+  // Field with directive
+  email: GqlField<string, { directives: [AuthDirective<{ role: ["ADMIN"] }>] }>;
+  // Nullable field with directive
+  phone: GqlField<string | null, { directives: [AuthDirective<{ role: ["USER"] }>] }>;
+};
+```
+
+Generates:
+
+```graphql
+type User {
+  id: ID!
+  name: String!
+  email: String! @auth(role: [ADMIN])
+  phone: String @auth(role: [USER])
+}
+```
+
+## Attaching Directives to Types
+
+Use `GqlObject` to attach directives to type definitions:
+
+```typescript
+import { type GqlObject, type IDString } from "@gqlkit-ts/runtime";
+import { type CacheDirective } from "./directives.js";
+
+export type Post = GqlObject<
+  {
+    id: IDString;
+    title: string;
+  },
+  { directives: [CacheDirective<{ maxAge: 60 }>] }
+>;
+```
+
+Generates:
+
+```graphql
+type Post @cache(maxAge: 60) {
+  id: ID!
+  title: String!
+}
+```
+
+## Attaching Directives to Query/Mutation Fields
+
+Add a third type parameter to `defineQuery`, `defineMutation`, or `defineField`:
+
+```typescript
+import { defineQuery } from "../gqlkit";
+import type { NoArgs } from "@gqlkit-ts/runtime";
+import { type AuthDirective } from "./directives.js";
+import type { User } from "./user.js";
+
+// Query field with directive
+export const me = defineQuery<
+  NoArgs,
+  User,
+  [AuthDirective<{ role: ["USER"] }>]
+>((_root, _args, ctx) => ctx.currentUser);
+```
+
+Generates:
+
+```graphql
+type Query {
+  me: User! @auth(role: [USER])
+}
+```
+
+## Attaching Directives to Field Resolvers
+
+```typescript
+import { defineField } from "../gqlkit";
+import type { NoArgs } from "@gqlkit-ts/runtime";
+import { type AuthDirective } from "./directives.js";
+
+export const email = defineField<
+  User,
+  NoArgs,
+  string,
+  [AuthDirective<{ role: ["ADMIN"] }>]
+>((parent) => parent.email);
+```
+
+## Multiple Directives
+
+Attach multiple directives by adding them to the array:
+
+```typescript
+export type Post = GqlObject<
+  {
+    id: IDString;
+    title: string;
+  },
+  {
+    directives: [
+      CacheDirective<{ maxAge: 60 }>,
+      AuthDirective<{ role: ["USER"] }>
+    ]
+  }
+>;
+```
+
+## Combining with Other Options
+
+Combine directives with `implements` and `defaultValue`:
+
+```typescript
+export type Post = GqlObject<
+  {
+    id: IDString;
+    title: string;
+    createdAt: DateTime;
+  },
+  {
+    implements: [Node, Timestamped],
+    directives: [CacheDirective<{ maxAge: 60 }>]
+  }
+>;
+
+export type CreatePostInput = {
+  title: GqlField<string, {
+    defaultValue: "Untitled";
+    directives: [LengthDirective<{ min: 1; max: 200 }>];
+  }>;
+};
+```

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/documentation.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/documentation.md
@@ -1,0 +1,181 @@
+---
+title: Adding Documentation to Schema
+description: gqlkit extracts TSDoc/JSDoc comments and converts them to GraphQL descriptions.
+---
+
+# Documentation
+
+gqlkit extracts TSDoc/JSDoc comments and converts them to GraphQL descriptions.
+
+## Type Descriptions
+
+Add descriptions to types using TSDoc/JSDoc comments:
+
+```typescript
+/**
+ * A user in the system
+ */
+export type User = {
+  /** Unique identifier */
+  id: IDString;
+  /** Display name */
+  name: string;
+};
+```
+
+Generates:
+
+```graphql
+"""
+A user in the system
+
+Defined in: src/gqlkit/schema/user.ts
+"""
+type User {
+  """Unique identifier"""
+  id: ID!
+  """Display name"""
+  name: String!
+}
+```
+
+## Field Descriptions
+
+Add descriptions to individual fields:
+
+```typescript
+export type User = {
+  /** Unique identifier for the user */
+  id: IDString;
+
+  /**
+   * The user's display name.
+   * This is shown in the UI and can be changed by the user.
+   */
+  name: string;
+
+  /** Email address (null if not verified) */
+  email: string | null;
+};
+```
+
+## Resolver Descriptions
+
+Add descriptions to Query, Mutation, and Field resolvers:
+
+```typescript
+/** Get the currently authenticated user */
+export const me = defineQuery<NoArgs, User | null>(
+  (_root, _args, ctx) => ctx.currentUser
+);
+
+/** Create a new user account */
+export const createUser = defineMutation<{ input: CreateUserInput }, User>(
+  (_root, args, ctx) => ctx.db.createUser(args.input)
+);
+
+/** Get user's profile URL */
+export const profileUrl = defineField<User, NoArgs, string>(
+  (parent) => `https://example.com/users/${parent.id}`
+);
+```
+
+## @deprecated Directive
+
+Mark fields and enum values as deprecated using the `@deprecated` JSDoc tag:
+
+### Deprecating Fields
+
+```typescript
+export type User = {
+  id: IDString;
+  name: string;
+  /**
+   * Legacy username
+   * @deprecated Use `name` field instead
+   */
+  username: string | null;
+};
+```
+
+Generates:
+
+```graphql
+type User {
+  id: ID!
+  name: String!
+  """Legacy username"""
+  username: String @deprecated(reason: "Use `name` field instead")
+}
+```
+
+### Deprecating Enum Values
+
+```typescript
+export enum UserStatus {
+  Active = "ACTIVE",
+  /**
+   * @deprecated Use `Inactive` instead
+   */
+  Pending = "PENDING",
+  Inactive = "INACTIVE",
+}
+```
+
+Generates:
+
+```graphql
+enum UserStatus {
+  ACTIVE
+  PENDING @deprecated(reason: "Use `Inactive` instead")
+  INACTIVE
+}
+```
+
+### Deprecating Resolvers
+
+```typescript
+/**
+ * Get user by username
+ * @deprecated Use `user(id: ID!)` instead
+ */
+export const userByUsername = defineQuery<{ username: string }, User | null>(
+  (_root, args, ctx) => ctx.db.findUserByUsername(args.username)
+);
+```
+
+## Multi-line Descriptions
+
+Multi-line comments are preserved:
+
+```typescript
+/**
+ * Represents a blog post.
+ *
+ * Posts can be in draft or published state.
+ * Only published posts are visible to other users.
+ */
+export type Post = {
+  id: IDString;
+  title: string;
+  content: string;
+};
+```
+
+Generates:
+
+```graphql
+"""
+Represents a blog post.
+
+Posts can be in draft or published state.
+Only published posts are visible to other users.
+
+Defined in: src/gqlkit/schema/post.ts
+"""
+type Post {
+  id: ID!
+  title: String!
+  content: String!
+}
+```

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/enums.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/enums.md
@@ -1,0 +1,469 @@
+---
+title: Defining Enum Types
+description: gqlkit converts TypeScript string literal unions and enums to GraphQL enum types.
+---
+
+# Enum Types
+
+gqlkit converts TypeScript string literal unions and enums to GraphQL enum types.
+
+## String Literal Unions
+
+String literal unions are automatically converted to GraphQL enum types:
+
+```typescript
+/**
+ * User account status
+ */
+export type UserStatus = "ACTIVE" | "INACTIVE" | "PENDING";
+```
+
+Generates:
+
+```graphql
+"""User account status"""
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+  PENDING
+}
+```
+
+## TypeScript Enums
+
+TypeScript string enums are also supported:
+
+```typescript
+export enum UserStatus {
+  Active = "ACTIVE",
+  Inactive = "INACTIVE",
+  Pending = "PENDING",
+}
+```
+
+Generates:
+
+```graphql
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+  PENDING
+}
+```
+
+## Deprecating Enum Values
+
+Use the `@deprecated` JSDoc tag to mark enum values as deprecated:
+
+```typescript
+export enum UserStatus {
+  Active = "ACTIVE",
+  /**
+   * @deprecated Use `Inactive` instead
+   */
+  Pending = "PENDING",
+  Inactive = "INACTIVE",
+}
+```
+
+For string literal unions, use a separate type with JSDoc:
+
+```typescript
+/**
+ * User account status
+ */
+export type UserStatus =
+  | "ACTIVE"
+  | /** @deprecated Use INACTIVE instead */ "PENDING"
+  | "INACTIVE";
+```
+
+Generates:
+
+```graphql
+enum UserStatus {
+  ACTIVE
+  PENDING @deprecated(reason: "Use INACTIVE instead")
+  INACTIVE
+}
+```
+
+## Using Enums in Types
+
+```typescript
+export type User = {
+  id: string;
+  name: string;
+  status: UserStatus;
+};
+
+export type UpdateUserInput = {
+  status: UserStatus | null;
+};
+```
+
+Generates:
+
+```graphql
+type User {
+  id: String!
+  name: String!
+  status: UserStatus!
+}
+
+input UpdateUserInput {
+  status: UserStatus
+}
+```
+
+## Inline Enums
+
+When you define a string literal union or reference a TypeScript enum **inline** (without exporting it from the schema directory), gqlkit automatically generates a GraphQL enum type. This follows the same pattern as [inline objects](./objects.md#inline-objects).
+
+### Inline String Literal Unions
+
+String literal unions used directly in field or argument types generate enum types automatically:
+
+```typescript
+export type User = {
+  id: string;
+  name: string;
+  /** Current account status */
+  status: "active" | "inactive" | "pendingReview";
+};
+```
+
+Generates:
+
+```graphql
+type User {
+  id: String!
+  name: String!
+  """Current account status"""
+  status: UserStatus!
+}
+
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+  PENDING_REVIEW
+}
+```
+
+The generated enum type name follows the convention `{ParentTypeName}{PascalCaseFieldName}`.
+
+### External TypeScript Enums
+
+TypeScript enums defined outside the schema directory are also automatically converted:
+
+```typescript
+// src/types/order.ts (outside schema directory)
+/**
+ * Order status in the system
+ */
+export enum OrderStatus {
+  /** Order is pending payment */
+  Pending = "pending",
+  /** Order is being processed */
+  Processing = "processing",
+  /** Order has been shipped */
+  Shipped = "shipped",
+}
+
+// src/gqlkit/schema/order.ts
+import { OrderStatus } from "../../types/order.js";
+
+export type Order = {
+  id: string;
+  status: OrderStatus;
+};
+```
+
+Generates:
+
+```graphql
+type Order {
+  id: String!
+  status: OrderStatus!
+}
+
+"""Order status in the system"""
+enum OrderStatus {
+  """Order is pending payment"""
+  PENDING
+  """Order is being processed"""
+  PROCESSING
+  """Order has been shipped"""
+  SHIPPED
+}
+```
+
+TSDoc comments on the enum and its values are preserved as GraphQL descriptions. The `@deprecated` tag is also supported.
+
+When the same external TypeScript enum is referenced in multiple places, gqlkit generates a single GraphQL enum type and reuses it across all references.
+
+### Inline Enum Naming Convention
+
+The naming convention for auto-generated enum types matches [inline objects](./objects.md#inline-objects):
+
+| Context | Naming Pattern | Example |
+|---------|----------------|---------|
+| Object field | `{ParentTypeName}{PascalCaseFieldName}` | `User.status` → `UserStatus` |
+| Input field | `{ParentTypeNameWithoutInputSuffix}{PascalCaseFieldName}Input` | `CreateUserInput.role` → `CreateUserRoleInput` |
+| Query/Mutation argument | `{PascalCaseFieldName}{PascalCaseArgName}Input` | `searchUsers(status: ...)` → `SearchUsersStatusInput` |
+| Field resolver argument | `{ParentTypeName}{PascalCaseFieldName}{PascalCaseArgName}Input` | `User.posts(filter: ...)` → `UserPostsFilterInput` |
+
+### Nullable Inline Enums
+
+Nullable inline enums are supported:
+
+```typescript
+export type User = {
+  id: string;
+  status: "active" | "inactive" | null;
+};
+```
+
+Generates:
+
+```graphql
+type User {
+  id: String!
+  status: UserStatus
+}
+
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+}
+```
+
+### Arrays of Inline Enums
+
+Inline enums in array types are also supported:
+
+```typescript
+export type User = {
+  id: string;
+  roles: ("admin" | "editor" | "viewer")[];
+};
+```
+
+Generates:
+
+```graphql
+type User {
+  id: String!
+  roles: [UserRoles!]!
+}
+
+enum UserRoles {
+  ADMIN
+  EDITOR
+  VIEWER
+}
+```
+
+### When Enums Are NOT Auto-Generated
+
+If you export a type from the schema directory, it is treated as an explicit type declaration and not auto-generated:
+
+```typescript
+// Exported from schema - used as-is, not auto-generated
+export type UserStatus = "active" | "inactive" | "pending";
+
+export type User = {
+  id: string;
+  status: UserStatus;  // References the exported type
+};
+```
+
+### Inline Enum Payloads
+
+String literal unions in resolver return types generate GraphQL Enum types with the naming convention `{ResolverName}Payload`:
+
+```typescript
+export const getStatus = defineQuery<NoArgs, "active" | "inactive" | "pending">(
+  (_root, _args, ctx) => ctx.db.getStatus()
+);
+```
+
+Generates:
+
+```graphql
+type Query {
+  getStatus: GetStatusPayload!
+}
+
+enum GetStatusPayload {
+  ACTIVE
+  INACTIVE
+  PENDING
+}
+```
+
+For field resolvers, the naming convention is `{ParentTypeName}{PascalCaseFieldName}Payload`:
+
+```typescript
+export const status = defineField<User, NoArgs, "online" | "offline" | "away">(
+  (parent) => parent.currentStatus
+);
+```
+
+Generates:
+
+```graphql
+type User {
+  status: UserStatusPayload!
+}
+
+enum UserStatusPayload {
+  ONLINE
+  OFFLINE
+  AWAY
+}
+```
+
+See [Queries & Mutations](./queries-mutations.md#inline-payload-types) for more details on inline payload types.
+
+## Automatic Case Conversion
+
+gqlkit automatically converts enum values to `SCREAMING_SNAKE_CASE` format, which is the GraphQL convention:
+
+```typescript
+export type UserStatus = "active" | "inProgress" | "pending_review" | "on-hold";
+```
+
+Generates:
+
+```graphql
+enum UserStatus {
+  ACTIVE
+  IN_PROGRESS
+  PENDING_REVIEW
+  ON_HOLD
+}
+```
+
+When conversion changes the original value, gqlkit generates resolver mappings to translate between GraphQL and TypeScript values:
+
+```typescript
+// Generated resolvers.ts
+export function createResolvers() {
+  return {
+    UserStatus: {
+      ACTIVE: "active",
+      IN_PROGRESS: "inProgress",
+      PENDING_REVIEW: "pending_review",
+      ON_HOLD: "on-hold",
+    },
+  };
+}
+```
+
+If values are already in `SCREAMING_SNAKE_CASE`, no resolver mapping is generated.
+
+### Automatic Prefix Stripping
+
+When all enum values share a common prefix that matches the enum name, gqlkit automatically strips the prefix to produce cleaner GraphQL values:
+
+```typescript
+export type UserStatus = "USER_STATUS_ACTIVE" | "USER_STATUS_INACTIVE" | "USER_STATUS_PENDING";
+```
+
+Generates:
+
+```graphql
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+  PENDING
+}
+```
+
+This works with various naming conventions:
+
+| TypeScript Enum | Values | Generated GraphQL Values |
+|-----------------|--------|--------------------------|
+| `UserStatus` | `USER_STATUS_ACTIVE`, `USER_STATUS_INACTIVE` | `ACTIVE`, `INACTIVE` |
+| `orderStatus` | `ORDER_STATUS_PENDING`, `ORDER_STATUS_SHIPPED` | `PENDING`, `SHIPPED` |
+| `Status` | `STATUS_ACTIVE`, `STATUS_INACTIVE` | `ACTIVE`, `INACTIVE` |
+
+Prefix stripping is **not applied** when:
+
+- Not all values share the common prefix
+- Stripping would result in an empty value (e.g., `USER_STATUS_` for `UserStatus`)
+
+When prefix stripping is applied, gqlkit generates resolver mappings to preserve the original TypeScript values:
+
+```typescript
+// Generated resolvers.ts
+export function createResolvers() {
+  return {
+    UserStatus: {
+      ACTIVE: "USER_STATUS_ACTIVE",
+      INACTIVE: "USER_STATUS_INACTIVE",
+      PENDING: "USER_STATUS_PENDING",
+    },
+  };
+}
+```
+
+### Duplicate Value Detection
+
+If multiple TypeScript values convert to the same GraphQL enum value, gqlkit reports a `DUPLICATE_ENUM_VALUE_AFTER_CONVERSION` error:
+
+```typescript
+// Error: 'activeUser' and 'active_user' both convert to ACTIVE_USER
+export type Status = "activeUser" | "active_user" | "pending";
+```
+
+## Invalid Enum Values
+
+Enum values that are not valid GraphQL identifiers are automatically skipped with a warning. gqlkit converts enum values to `SCREAMING_SNAKE_CASE`, and the converted name must:
+
+- Match the pattern `/^[_A-Za-z][_0-9A-Za-z]*$/`
+- Not start with `__` (reserved for GraphQL introspection)
+
+### String Literal Unions
+
+```typescript
+export type Status =
+  | "active"      // ✅ Converts to ACTIVE
+  | "inProgress"  // ✅ Converts to IN_PROGRESS
+  | "0pending"    // ⚠️ Skipped: converts to 0PENDING (starts with number)
+  | "__internal"; // ⚠️ Skipped: converts to __INTERNAL (starts with __)
+```
+
+Generates:
+
+```graphql
+enum Status {
+  ACTIVE
+  IN_PROGRESS
+}
+```
+
+### TypeScript Enums
+
+```typescript
+export enum Priority {
+  HIGH = "HIGH",           // ✅ Valid
+  MEDIUM = "MEDIUM",       // ✅ Valid
+  LOW = "LOW",             // ✅ Valid
+  "0INVALID" = "0INVALID", // ⚠️ Skipped: starts with number
+  __RESERVED = "__RESERVED", // ⚠️ Skipped: starts with __
+}
+```
+
+Generates:
+
+```graphql
+enum Priority {
+  HIGH
+  MEDIUM
+  LOW
+}
+```
+
+When enum values are skipped, gqlkit outputs a warning with the original name, converted name, and location.

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/fields.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/fields.md
@@ -1,0 +1,250 @@
+---
+title: Defining Field Resolvers
+description: Add computed fields to object types using defineField.
+---
+
+# Field Resolvers
+
+Add computed fields to object types using `defineField`. Define them alongside the type.
+
+## Basic Usage
+
+```typescript
+// src/gqlkit/schema/user.ts
+import { defineField } from "../gqlkit";
+import type { IDString, NoArgs } from "@gqlkit-ts/runtime";
+import type { Post } from "./post.js";
+
+export type User = {
+  id: IDString;
+  name: string;
+};
+
+/** Get posts authored by this user */
+export const posts = defineField<User, NoArgs, Post[]>(
+  (parent) => findPostsByAuthor(parent.id)
+);
+
+/** Get user's post count */
+export const postCount = defineField<User, NoArgs, number>(
+  (parent) => countPostsByAuthor(parent.id)
+);
+```
+
+Generates:
+
+```graphql
+type User {
+  id: ID!
+  name: String!
+  """Get posts authored by this user"""
+  posts: [Post!]!
+  """Get user's post count"""
+  postCount: Float!
+}
+```
+
+## Resolver Function Signature
+
+Field resolvers receive four arguments:
+
+```typescript
+(parent, args, ctx, info) => ReturnType
+```
+
+| Argument | Description |
+|----------|-------------|
+| `parent` | The parent object (typed via the first type parameter) |
+| `args` | The arguments passed to the field |
+| `ctx` | The context object (typed via `gqlkit.ts`) |
+| `info` | GraphQL resolve info |
+
+## Type Parameters
+
+`defineField<TParent, TArgs, TResult>`:
+
+| Parameter | Description |
+|-----------|-------------|
+| `TParent` | The parent object type this field is defined on |
+| `TArgs` | The arguments type (use `NoArgs` if no arguments) |
+| `TResult` | The return type of the field |
+
+## Fields with Arguments
+
+```typescript
+export const posts = defineField<
+  User,
+  { limit: number; offset: number },
+  Post[]
+>((parent, args) => {
+  return findPostsByAuthor(parent.id, args.limit, args.offset);
+});
+```
+
+Generates:
+
+```graphql
+type User {
+  posts(limit: Float!, offset: Float!): [Post!]!
+}
+```
+
+## Inline Object Arguments
+
+Field resolver arguments can use inline object literals. gqlkit automatically generates Input Object types with the naming convention `{ParentTypeName}{PascalCaseFieldName}{PascalCaseArgName}Input`:
+
+```typescript
+import { defineField } from "../gqlkit";
+
+export const posts = defineField<
+  User,
+  {
+    /** Filter options */
+    filter: {
+      titlePattern: string | null;
+      status: PostStatus | null;
+    } | null;
+  },
+  Post[]
+>((parent, args) => []);
+```
+
+Generates:
+
+```graphql
+type User {
+  posts(
+    """Filter options"""
+    filter: UserPostsFilterInput
+  ): [Post!]!
+}
+
+input UserPostsFilterInput {
+  titlePattern: String
+  status: PostStatus
+}
+```
+
+Inline string literal unions and external TypeScript enums in arguments are also automatically converted to GraphQL enum types. See [Inline Enums](./enums.md#inline-enums) for details.
+
+## Inline Payload Types
+
+Field resolver return types can use inline object literals. gqlkit automatically generates GraphQL Object types with the naming convention `{ParentTypeName}{PascalCaseFieldName}Payload`:
+
+```typescript
+export const statistics = defineField<
+  User,
+  NoArgs,
+  { postCount: number; followerCount: number; isActive: boolean }
+>((parent, _args, ctx) => ctx.db.getUserStatistics(parent.id));
+```
+
+Generates:
+
+```graphql
+type User {
+  statistics: UserStatisticsPayload!
+}
+
+type UserStatisticsPayload {
+  postCount: Float!
+  followerCount: Float!
+  isActive: Boolean!
+}
+```
+
+### Inline Union Payloads
+
+Union types with inline object literals generate GraphQL Union types. Each union member must have a `__typename` property:
+
+```typescript
+export const verification = defineField<
+  User,
+  NoArgs,
+  | { __typename: "Verified"; verifiedAt: string }
+  | { __typename: "Unverified"; reason: string }
+>((parent) => parent.verification);
+```
+
+Generates:
+
+```graphql
+type User {
+  verification: UserVerificationPayload!
+}
+
+union UserVerificationPayload = Unverified | Verified
+
+type Verified {
+  verifiedAt: String!
+}
+
+type Unverified {
+  reason: String!
+}
+```
+
+See [Queries & Mutations](./queries-mutations.md#inline-payload-types) for more details on inline payload types.
+
+## Default Values in Arguments
+
+Default values in Input Objects are applied to resolver arguments:
+
+```typescript
+import { defineQuery } from "../gqlkit";
+import type { GqlField, Int } from "@gqlkit-ts/runtime";
+
+export type PaginationInput = {
+  limit: GqlField<Int, { defaultValue: 10 }>;
+  offset: GqlField<Int, { defaultValue: 0 }>;
+};
+
+export type User = {
+  id: string;
+  name: string;
+};
+
+export const users = defineQuery<PaginationInput, User[]>(() => []);
+```
+
+Generates:
+
+```graphql
+type Query {
+  users(limit: Int! = 10, offset: Int! = 0): [User!]!
+}
+```
+
+## Interface Field Resolvers
+
+Add computed fields to interface types using `defineField`:
+
+```typescript
+import { defineField } from "../gqlkit";
+import type { NoArgs } from "@gqlkit-ts/runtime";
+import type { Node } from "./node.js";
+
+/** Get the typename of a Node */
+export const __typename = defineField<Node, NoArgs, string>(
+  (parent) => parent.constructor.name
+);
+```
+
+## Attaching Directives
+
+Add a fourth type parameter to attach directives to field resolvers:
+
+```typescript
+import { defineField } from "../gqlkit";
+import type { NoArgs } from "@gqlkit-ts/runtime";
+import { type AuthDirective } from "./directives.js";
+
+export const email = defineField<
+  User,
+  NoArgs,
+  string,
+  [AuthDirective<{ role: ["ADMIN"] }>]
+>((parent) => parent.email);
+```
+
+See [Directives](./directives.md) for more details on defining and using custom directives.

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/inputs.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/inputs.md
@@ -1,0 +1,379 @@
+---
+title: Defining Input Types
+description: TypeScript types with Input suffix are treated as GraphQL input types.
+---
+
+# Input Types
+
+TypeScript types with `Input` suffix are treated as GraphQL input types.
+
+## Basic Usage
+
+```typescript
+/** Input for creating a new user */
+export interface CreateUserInput {
+  name: string;
+  email: string | null;
+}
+```
+
+Generates:
+
+```graphql
+"""Input for creating a new user"""
+input CreateUserInput {
+  name: String!
+  email: String
+}
+```
+
+## Inline Objects
+
+Input types can use inline object literals for nested structures. gqlkit automatically generates Input Object types with the naming convention `{ParentTypeNameWithoutInputSuffix}{PascalCaseFieldName}Input`:
+
+```typescript
+import type { GqlField, Int } from "@gqlkit-ts/runtime";
+
+export type CreateUserInput = {
+  name: string;
+  /** Profile information */
+  profile: {
+    bio: string | null;
+    /** User's age with default value */
+    age: GqlField<Int | null, { defaultValue: 18 }>;
+  };
+};
+```
+
+Generates:
+
+```graphql
+input CreateUserInput {
+  name: String!
+  """Profile information"""
+  profile: CreateUserProfileInput!
+}
+
+input CreateUserProfileInput {
+  """User's age with default value"""
+  age: Int = 18
+  bio: String
+}
+```
+
+Nested inline objects generate types with concatenated names (e.g., `UserProfileInput.address` → `UserProfileAddressInput`).
+
+Similarly, inline string literal unions and external TypeScript enums are automatically converted to GraphQL enum types. See [Inline Enums](./enums.md#inline-enums) for details.
+
+## @oneOf Input Objects
+
+Union types with `Input` suffix using inline object literals generate `@oneOf` input objects. Each union member must be an inline object literal with exactly one property. Property values can be scalar types, enum types, or references to Input Object types:
+
+```typescript
+/**
+ * Specifies how to identify a product.
+ * Exactly one field must be provided.
+ */
+export type ProductInput =
+  | { id: string }
+  | { name: string }
+  | { location: LocationInput };
+```
+
+Generates:
+
+```graphql
+"""
+Specifies how to identify a product.
+Exactly one field must be provided.
+"""
+input ProductInput @oneOf {
+  id: String
+  location: LocationInput
+  name: String
+}
+```
+
+Each property becomes a nullable field in the generated input type. The `@oneOf` directive ensures exactly one field is provided at runtime.
+
+### Inline @oneOf in Input Fields
+
+Union types can be used as field types within Input Objects to create nested `@oneOf` input objects. The generated type name follows the convention `{ParentTypeNameWithoutInputSuffix}{PascalCaseFieldName}Input`:
+
+```typescript
+export type CreateUserInput = {
+  name: string;
+  /**
+   * User identifier - either by ID or email
+   */
+  identifier: { id: string } | { email: string };
+};
+```
+
+Generates:
+
+```graphql
+input CreateUserInput {
+  name: String!
+  """User identifier - either by ID or email"""
+  identifier: CreateUserIdentifierInput!
+}
+
+input CreateUserIdentifierInput @oneOf {
+  email: String
+  id: String
+}
+```
+
+### Inline @oneOf in Resolver Arguments
+
+Inline unions in resolver arguments are also converted to `@oneOf` input objects:
+
+**Query/Mutation arguments** - naming convention: `{PascalCaseResolverName}{PascalCaseArgPath}Input`
+
+```typescript
+export const findUser = defineQuery<
+  {
+    criteria: {
+      identifier: { id: string } | { email: string };
+    };
+  },
+  User | null
+>(...);
+```
+
+Generates:
+
+```graphql
+input FindUserCriteriaIdentifierInput @oneOf {
+  email: String
+  id: String
+}
+
+input FindUserCriteriaInput {
+  identifier: FindUserCriteriaIdentifierInput!
+}
+
+type Query {
+  findUser(criteria: FindUserCriteriaInput!): User
+}
+```
+
+**Field resolver arguments** - naming convention: `{ParentTypeName}{PascalCaseFieldName}{PascalCaseArgPath}Input`
+
+```typescript
+export const posts = defineField<
+  User,
+  {
+    filter: { status: string } | { createdAfter: string } | null;
+  },
+  Post[]
+>(...);
+```
+
+Generates:
+
+```graphql
+input UserPostsFilterInput @oneOf {
+  createdAfter: String
+  status: String
+}
+
+type User {
+  posts(filter: UserPostsFilterInput): [Post!]!
+}
+```
+
+## Default Values
+
+Specify default values for Input Object fields using `GqlField` with the `defaultValue` option.
+
+### Basic Default Values
+
+```typescript
+import { type GqlField, type Int } from "@gqlkit-ts/runtime";
+
+export type PaginationInput = {
+  limit: GqlField<Int, { defaultValue: 10 }>;
+  offset: GqlField<Int, { defaultValue: 0 }>;
+  includeArchived: GqlField<boolean, { defaultValue: false }>;
+};
+
+export type SearchInput = {
+  query: string;
+  caseSensitive: GqlField<boolean, { defaultValue: true }>;
+  maxResults: GqlField<Int | null, { defaultValue: null }>;
+};
+
+export type GreetingInput = {
+  name: GqlField<string, { defaultValue: "World" }>;
+  prefix: GqlField<string, { defaultValue: "Hello" }>;
+};
+```
+
+Generates:
+
+```graphql
+input PaginationInput {
+  limit: Int! = 10
+  offset: Int! = 0
+  includeArchived: Boolean! = false
+}
+
+input SearchInput {
+  query: String!
+  caseSensitive: Boolean! = true
+  maxResults: Int = null
+}
+
+input GreetingInput {
+  name: String! = "World"
+  prefix: String! = "Hello"
+}
+```
+
+### Complex Default Values
+
+Default values support arrays, objects, and enum values:
+
+```typescript
+export type Status = "ACTIVE" | "INACTIVE" | "PENDING";
+
+export type Priority = "LOW" | "MEDIUM" | "HIGH";
+
+export type NestedConfig = {
+  enabled: boolean;
+  value: Int;
+};
+
+export type FilterInput = {
+  status: GqlField<Status, { defaultValue: "ACTIVE" }>;
+  priorities: GqlField<Priority[], { defaultValue: ["MEDIUM", "HIGH"] }>;
+  tags: GqlField<string[], { defaultValue: ["default"] }>;
+};
+
+export type SettingsInput = {
+  config: GqlField<NestedConfig, { defaultValue: { enabled: true; value: 100 } }>;
+  limits: GqlField<Int[], { defaultValue: [10, 20, 30] }>;
+};
+```
+
+Generates:
+
+```graphql
+input FilterInput {
+  status: Status! = ACTIVE
+  priorities: [Priority!]! = [MEDIUM, HIGH]
+  tags: [String!]! = ["default"]
+}
+
+input SettingsInput {
+  config: NestedConfig! = {enabled: true, value: 100}
+  limits: [Int!]! = [10, 20, 30]
+}
+```
+
+### Default Values with Directives
+
+You can combine `defaultValue` with `directives`:
+
+```typescript
+import { type GqlField, type GqlDirective, type Int } from "@gqlkit-ts/runtime";
+
+export type LengthDirective<TArgs extends { min: number; max: number }> =
+  GqlDirective<"length", TArgs, "INPUT_FIELD_DEFINITION" | "ARGUMENT_DEFINITION">;
+
+export type RangeDirective<TArgs extends { min: number; max: number }> =
+  GqlDirective<"range", TArgs, "INPUT_FIELD_DEFINITION" | "ARGUMENT_DEFINITION">;
+
+export type CreateUserInput = {
+  name: GqlField<string, {
+    defaultValue: "Anonymous";
+    directives: [LengthDirective<{ min: 1; max: 100 }>];
+  }>;
+  age: GqlField<Int, {
+    defaultValue: 18;
+    directives: [RangeDirective<{ min: 0; max: 150 }>];
+  }>;
+  email: GqlField<string | null, {
+    defaultValue: null;
+    directives: [LengthDirective<{ min: 5; max: 255 }>];
+  }>;
+};
+```
+
+Generates:
+
+```graphql
+input CreateUserInput {
+  name: String! = "Anonymous" @length(min: 1, max: 100)
+  age: Int! = 18 @range(min: 0, max: 150)
+  email: String = null @length(min: 5, max: 255)
+}
+```
+
+### Supported Default Value Types
+
+| Value type | Example | GraphQL output |
+|------------|---------|----------------|
+| String | `"hello"` | `"hello"` |
+| Number (Int) | `10` | `10` |
+| Number (Float) | `3.14` | `3.14` |
+| Boolean | `true`, `false` | `true`, `false` |
+| Null | `null` | `null` |
+| Array | `[1, 2, 3]` | `[1, 2, 3]` |
+| Object | `{ key: "value" }` | `{key: "value"}` |
+| Enum | `"ACTIVE"` (when field type is enum) | `ACTIVE` |
+
+### Literal Types Required
+
+Default values must be specified as TypeScript literal types. Non-literal types will cause a warning:
+
+```typescript
+// ✅ OK: Literal types
+export type GoodInput = {
+  limit: GqlField<Int, { defaultValue: 10 }>;
+  name: GqlField<string, { defaultValue: "default" }>;
+};
+
+// ❌ Error: Non-literal types
+export type BadInput = {
+  limit: GqlField<Int, { defaultValue: number }>;     // Warning: must be literal
+  name: GqlField<string, { defaultValue: string }>;   // Warning: must be literal
+};
+```
+
+## Excluding Fields
+
+Use `GqlObject` with the `ignoreFields` option to exclude specific fields from the generated Input Object. This is useful for internal fields that should not be accepted from clients:
+
+```typescript
+import { type GqlObject } from "@gqlkit-ts/runtime";
+
+/**
+ * Input for creating a user.
+ */
+export type CreateUserInput = GqlObject<
+  {
+    name: string;
+    email: string;
+    internalData: string;  // Internal field - excluded from schema
+    trackingId: string;    // Internal field - excluded from schema
+  },
+  { ignoreFields: "internalData" | "trackingId" }
+>;
+```
+
+Generates:
+
+```graphql
+"""Input for creating a user."""
+input CreateUserInput {
+  name: String!
+  email: String!
+}
+```
+
+## Invalid Field Names
+
+Input field names follow the same validation rules as object type fields. See [Invalid Field Names](./objects.md#invalid-field-names) for details.

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/interfaces.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/interfaces.md
@@ -1,0 +1,208 @@
+---
+title: Defining Interface Types
+description: Define GraphQL interface types using the GqlInterface utility type.
+---
+
+# Interface Types
+
+Define GraphQL interface types using the `GqlInterface` utility type.
+
+## Basic Usage
+
+```typescript
+// src/gqlkit/schema/node.ts
+import { type GqlInterface, type IDString } from "@gqlkit-ts/runtime";
+import type { DateTime } from "./scalars.js";
+
+/**
+ * Node interface - represents any entity with a unique identifier.
+ */
+export type Node = GqlInterface<{
+  /** Global unique identifier */
+  id: IDString;
+}>;
+
+/**
+ * Timestamped interface - entities that track creation time.
+ */
+export type Timestamped = GqlInterface<{
+  createdAt: DateTime;
+}>;
+```
+
+Generates:
+
+```graphql
+"""Node interface - represents any entity with a unique identifier."""
+interface Node {
+  """Global unique identifier"""
+  id: ID!
+}
+
+"""Timestamped interface - entities that track creation time."""
+interface Timestamped {
+  createdAt: DateTime!
+}
+```
+
+## GqlInterface Type Parameters
+
+`GqlInterface<T, Meta?>`:
+
+| Parameter | Description |
+|-----------|-------------|
+| `T` | The interface fields definition |
+| `Meta` | Optional: `{ implements: [...] }` for interface inheritance |
+
+## Interface Inheritance
+
+Interfaces can extend other interfaces:
+
+```typescript
+/**
+ * Entity interface - combines Node and Timestamped.
+ */
+export type Entity = GqlInterface<
+  {
+    id: IDString;
+    createdAt: DateTime;
+  },
+  { implements: [Node, Timestamped] }
+>;
+```
+
+Generates:
+
+```graphql
+"""Entity interface - combines Node and Timestamped."""
+interface Entity implements Node & Timestamped {
+  id: ID!
+  createdAt: DateTime!
+}
+```
+
+## Implementing Interfaces
+
+Use `GqlObject` with the `implements` option to declare that a type implements interfaces:
+
+```typescript
+import { type GqlObject, type IDString } from "@gqlkit-ts/runtime";
+import type { Node, Timestamped } from "./node.js";
+import type { DateTime } from "./scalars.js";
+
+/**
+ * A user in the system.
+ */
+export type User = GqlObject<
+  {
+    id: IDString;
+    name: string;
+    email: string | null;
+    createdAt: DateTime;
+  },
+  { implements: [Node, Timestamped] }
+>;
+```
+
+Generates:
+
+```graphql
+"""A user in the system."""
+type User implements Node & Timestamped {
+  id: ID!
+  name: String!
+  email: String
+  createdAt: DateTime!
+}
+```
+
+## Combining with Directives
+
+You can combine `implements` with `directives`:
+
+```typescript
+import { type GqlObject, type IDString } from "@gqlkit-ts/runtime";
+import type { Node, Timestamped } from "./node.js";
+import type { DateTime } from "./scalars.js";
+import type { CacheDirective } from "./directives.js";
+
+export type Post = GqlObject<
+  {
+    id: IDString;
+    title: string;
+    createdAt: DateTime;
+  },
+  {
+    implements: [Node, Timestamped],
+    directives: [CacheDirective<{ maxAge: 60 }>]
+  }
+>;
+```
+
+Generates:
+
+```graphql
+type Post @cache(maxAge: 60) implements Node & Timestamped {
+  id: ID!
+  title: String!
+  createdAt: DateTime!
+}
+```
+
+## Interface Field Resolvers
+
+Add computed fields to interface types using `defineField`:
+
+```typescript
+import { defineField } from "../gqlkit";
+import type { NoArgs } from "@gqlkit-ts/runtime";
+import type { Node } from "./node.js";
+
+/** Get the typename of a Node */
+export const __typename = defineField<Node, NoArgs, string>(
+  (parent) => parent.constructor.name
+);
+```
+
+See [Object Types](./objects.md) for more details on implementing interfaces.
+
+## Runtime Type Resolution
+
+When GraphQL executes a query that returns an interface type, it needs to determine the concrete type at runtime.
+
+### Automatic Resolution
+
+If all implementing types have `__typename` or `$typeName` fields with string literal values, gqlkit automatically generates the `resolveType` function:
+
+```typescript
+export interface User {
+  __typename: "User";
+  id: IDString;
+  name: string;
+}
+
+export interface Post {
+  __typename: "Post";
+  id: IDString;
+  title: string;
+}
+
+// Both User and Post implement Node
+// resolveType is automatically generated - no manual definition needed
+```
+
+### Manual Resolution
+
+For types without `__typename` or `$typeName`, use `defineResolveType` on the interface or `defineIsTypeOf` on each implementing type:
+
+```typescript
+import { defineResolveType } from "../gqlkit";
+
+export const nodeResolveType = defineResolveType<Node>((value) => {
+  if ("name" in value) return "User";
+  if ("title" in value) return "Post";
+  throw new Error("Unknown Node type");
+});
+```
+
+See [Abstract Type Resolution](./abstract-resolvers.md) for complete documentation.

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/objects.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/objects.md
@@ -1,0 +1,228 @@
+---
+title: Defining Object Types
+description: Plain TypeScript type exports become GraphQL Object types.
+---
+
+# Object Types
+
+Plain TypeScript type exports become GraphQL Object types.
+
+## Basic Usage
+
+Export a TypeScript type or interface:
+
+```typescript
+// src/gqlkit/schema/user.ts
+import { defineQuery, defineField } from "../gqlkit";
+import type { IDString, Int, NoArgs } from "@gqlkit-ts/runtime";
+
+/**
+ * A user in the system
+ */
+export type User = {
+  /** Unique identifier */
+  id: IDString;
+  /** Display name */
+  name: string;
+  /** Age in years */
+  age: Int;
+  /** Email address (null if not verified) */
+  email: string | null;
+};
+
+export const me = defineQuery<NoArgs, User | null>((_root, _args, ctx) => {
+  return findUserById(ctx.currentUserId);
+});
+
+/** Get user's profile URL */
+export const profileUrl = defineField<User, NoArgs, string>((parent) => {
+  return `https://example.com/users/${parent.id}`;
+});
+```
+
+## Nullability
+
+Use union with `null` to make fields nullable:
+
+```typescript
+export type User = {
+  email: string | null;  // nullable
+  name: string;          // non-null
+};
+```
+
+Generates:
+
+```graphql
+type User {
+  email: String
+  name: String!
+}
+```
+
+## Arrays
+
+Arrays are automatically converted to GraphQL lists:
+
+```typescript
+export type User = {
+  tags: string[];           // [String!]!
+  posts: Post[] | null;     // [Post!]
+};
+```
+
+## Inline Objects
+
+Object type fields can use inline object literals for nested structures. gqlkit automatically generates Object types with the naming convention `{ParentTypeName}{PascalCaseFieldName}`:
+
+```typescript
+export type User = {
+  id: string;
+  name: string;
+  /** User's profile information */
+  profile: {
+    /** User's biography */
+    bio: string;
+    age: number;
+  };
+};
+```
+
+Generates:
+
+```graphql
+type User {
+  id: String!
+  name: String!
+  """User's profile information"""
+  profile: UserProfile!
+}
+
+type UserProfile {
+  """User's biography"""
+  bio: String!
+  age: Float!
+}
+```
+
+Nested inline objects generate types with concatenated names (e.g., `User.profile.address` → `UserProfileAddress`).
+
+Similarly, inline string literal unions and external TypeScript enums are automatically converted to GraphQL enum types. See [Inline Enums](./enums.md#inline-enums) for details.
+
+## Implementing Interfaces
+
+Use `GqlObject` with the `implements` option to declare that a type implements interfaces:
+
+```typescript
+import { type GqlObject, type IDString } from "@gqlkit-ts/runtime";
+import type { Node, Timestamped } from "./node.js";
+import type { DateTime } from "./scalars.js";
+
+/**
+ * A user in the system.
+ */
+export type User = GqlObject<
+  {
+    id: IDString;
+    name: string;
+    email: string | null;
+    createdAt: DateTime;
+  },
+  { implements: [Node, Timestamped] }
+>;
+```
+
+Generates:
+
+```graphql
+"""A user in the system."""
+type User implements Node & Timestamped {
+  id: ID!
+  name: String!
+  email: String
+  createdAt: DateTime!
+}
+```
+
+You can combine `implements` with `directives`:
+
+```typescript
+export type Post = GqlObject<
+  {
+    id: IDString;
+    title: string;
+    createdAt: DateTime;
+  },
+  {
+    implements: [Node, Timestamped],
+    directives: [CacheDirective<{ maxAge: 60 }>]
+  }
+>;
+```
+
+See [Interfaces](./interfaces.md) for more details on defining interface types.
+
+## Excluding Fields
+
+Use `GqlObject` with the `ignoreFields` option to exclude specific fields from the generated GraphQL schema. This is useful for internal fields that should not be exposed in the public API:
+
+```typescript
+import { type GqlObject, type IDString } from "@gqlkit-ts/runtime";
+
+/**
+ * A user in the system.
+ */
+export type User = GqlObject<
+  {
+    id: IDString;
+    name: string;
+    email: string | null;
+    internalId: string;  // Internal field - excluded from schema
+    cacheKey: string;    // Internal field - excluded from schema
+  },
+  { ignoreFields: "internalId" | "cacheKey" }
+>;
+```
+
+Generates:
+
+```graphql
+"""A user in the system."""
+type User {
+  id: ID!
+  name: String!
+  email: String
+}
+```
+
+The excluded fields (`internalId` and `cacheKey`) are not included in the generated schema, and no resolvers are generated for them.
+
+## Invalid Field Names
+
+Field names that are not valid GraphQL identifiers are automatically skipped with a warning. Valid GraphQL names must:
+
+- Match the pattern `/^[_A-Za-z][_0-9A-Za-z]*$/`
+- Not start with `__` (reserved for GraphQL introspection)
+
+```typescript
+export type User = {
+  id: string;              // ✅ Valid
+  userName: string;        // ✅ Valid
+  _internal: string;       // ✅ Valid (single underscore is OK)
+  "0invalid": string;      // ⚠️ Skipped: starts with a number
+  __reserved: string;      // ⚠️ Skipped: starts with __
+  "field-name": string;    // ⚠️ Skipped: contains hyphen
+};
+```
+
+Generates (invalid fields are skipped):
+
+```graphql
+type User {
+  id: String!
+  userName: String!
+  _internal: String!
+}
+```
+
+When fields are skipped, gqlkit outputs a warning with the field name and location.

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/queries-mutations.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/queries-mutations.md
@@ -1,0 +1,321 @@
+---
+title: Defining Queries and Mutations
+description: Define Query and Mutation fields using the @gqlkit-ts/runtime API.
+---
+
+# Queries & Mutations
+
+Define Query and Mutation fields using the `@gqlkit-ts/runtime` API.
+
+> **Prerequisites**: This guide assumes you have completed the [basic setup](../getting-started.md#set-up-context-and-resolver-factories).
+
+## Query Resolvers
+
+Use `defineQuery` to define Query fields. The export name becomes the GraphQL field name:
+
+```typescript
+import { defineQuery } from "../gqlkit";
+import type { NoArgs } from "@gqlkit-ts/runtime";
+import type { User } from "./user";
+
+// Query.me
+export const me = defineQuery<NoArgs, User | null>(
+  (_root, _args, ctx) => {
+    return ctx.db.findUser(ctx.userId);
+  }
+);
+
+// Query.user(id: String!)
+export const user = defineQuery<{ id: string }, User | null>(
+  (_root, args, ctx) => {
+    return ctx.db.findUser(args.id);
+  }
+);
+
+// Query.users
+export const users = defineQuery<NoArgs, User[]>(
+  (_root, _args, ctx) => {
+    return ctx.db.findAllUsers();
+  }
+);
+```
+
+Generates:
+
+```graphql
+type Query {
+  me: User
+  user(id: String!): User
+  users: [User!]!
+}
+```
+
+## Mutation Resolvers
+
+Use `defineMutation` to define Mutation fields:
+
+```typescript
+import { defineMutation } from "../gqlkit";
+import type { User, CreateUserInput } from "./user";
+
+// Mutation.createUser(input: CreateUserInput!)
+export const createUser = defineMutation<{ input: CreateUserInput }, User>(
+  (_root, args, ctx) => {
+    return ctx.db.createUser(args.input);
+  }
+);
+
+// Mutation.deleteUser(id: String!)
+export const deleteUser = defineMutation<{ id: string }, boolean>(
+  (_root, args, ctx) => {
+    return ctx.db.deleteUser(args.id);
+  }
+);
+```
+
+Generates:
+
+```graphql
+type Mutation {
+  createUser(input: CreateUserInput!): User!
+  deleteUser(id: String!): Boolean!
+}
+```
+
+## Resolver Function Signature
+
+Query and Mutation resolvers receive four arguments:
+
+```typescript
+(root, args, ctx, info) => ReturnType
+```
+
+| Argument | Description |
+|----------|-------------|
+| `root` | The root value (usually undefined) |
+| `args` | The arguments passed to the field |
+| `ctx` | The context object (typed via `createGqlkitApis<Context>()`) |
+| `info` | GraphQL resolve info |
+
+## NoArgs Type
+
+Use the `NoArgs` type when a field has no arguments:
+
+```typescript
+import { type NoArgs } from "@gqlkit-ts/runtime";
+
+export const me = defineQuery<NoArgs, User | null>(
+  (_root, _args, ctx) => ctx.currentUser
+);
+```
+
+## Arguments with Input Types
+
+Use Input types for complex arguments:
+
+```typescript
+export type SearchUsersInput = {
+  query: string;
+  limit: number | null;
+};
+
+export const searchUsers = defineQuery<{ input: SearchUsersInput }, User[]>(
+  (_root, args) => {
+    return findUsers(args.input.query, args.input.limit ?? 10);
+  }
+);
+```
+
+## Inline Object Arguments
+
+Arguments can use inline object literals. gqlkit automatically generates Input Object types:
+
+```typescript
+export const searchUsers = defineQuery<
+  {
+    /** Search filter */
+    filter: {
+      namePattern: string | null;
+      status: UserStatus | null;
+    };
+  },
+  User[]
+>((_root, args) => []);
+```
+
+Generates:
+
+```graphql
+type Query {
+  searchUsers(
+    """Search filter"""
+    filter: SearchUsersFilterInput!
+  ): [User!]!
+}
+
+input SearchUsersFilterInput {
+  namePattern: String
+  status: UserStatus
+}
+```
+
+Inline string literal unions and external TypeScript enums in arguments are also automatically converted to GraphQL enum types. See [Inline Enums](./enums.md#inline-enums) for details.
+
+See [Field Resolvers](./fields.md) for more details on inline object arguments.
+
+## Inline Payload Types
+
+Return types can use inline object literals. gqlkit automatically generates GraphQL Object types with the naming convention `{PascalCaseResolverName}Payload`:
+
+```typescript
+export const updateUser = defineMutation<
+  { input: UpdateUserInput },
+  { user: User; updatedAt: string }
+>((_root, args, ctx) => ({
+  user: ctx.db.updateUser(args.input),
+  updatedAt: new Date().toISOString(),
+}));
+```
+
+Generates:
+
+```graphql
+type Mutation {
+  updateUser(input: UpdateUserInput!): UpdateUserPayload!
+}
+
+type UpdateUserPayload {
+  user: User!
+  updatedAt: String!
+}
+```
+
+### Inline Union Payloads
+
+Union types with inline object literals generate GraphQL Union types. Each union member must have a `__typename` property with a string literal type:
+
+```typescript
+export const updateUser = defineMutation<
+  { input: UpdateUserInput },
+  | { __typename: "UpdateUserSuccess"; user: User }
+  | { __typename: "UpdateUserError"; message: string }
+>((_root, args, ctx) => {
+  const result = ctx.db.updateUser(args.input);
+  if (result.ok) {
+    return { __typename: "UpdateUserSuccess", user: result.user };
+  }
+  return { __typename: "UpdateUserError", message: result.error };
+});
+```
+
+Generates:
+
+```graphql
+type Mutation {
+  updateUser(input: UpdateUserInput!): UpdateUserPayload!
+}
+
+union UpdateUserPayload = UpdateUserError | UpdateUserSuccess
+
+type UpdateUserSuccess {
+  user: User!
+}
+
+type UpdateUserError {
+  message: String!
+}
+```
+
+The `__resolveType` function is automatically generated based on the `__typename` property. See [Abstract Type Resolution](./abstract-resolvers.md) for more details.
+
+### Inline Enum Payloads
+
+String literal unions in return types generate GraphQL Enum types:
+
+```typescript
+export const getStatus = defineQuery<NoArgs, "active" | "inactive" | "pending">(
+  (_root, _args, ctx) => ctx.db.getStatus()
+);
+```
+
+Generates:
+
+```graphql
+type Query {
+  getStatus: GetStatusPayload!
+}
+
+enum GetStatusPayload {
+  ACTIVE
+  INACTIVE
+  PENDING
+}
+```
+
+### Nested Inline Types
+
+Inline types can be nested within payload objects:
+
+```typescript
+export const createOrder = defineMutation<
+  { input: CreateOrderInput },
+  {
+    order: {
+      id: string;
+      status: "pending" | "confirmed";
+      items: { productId: string; quantity: number }[];
+    };
+  }
+>(/* ... */);
+```
+
+Generates:
+
+```graphql
+type CreateOrderPayload {
+  order: CreateOrderPayloadOrder!
+}
+
+type CreateOrderPayloadOrder {
+  id: String!
+  status: CreateOrderPayloadOrderStatus!
+  items: [CreateOrderPayloadOrderItems!]!
+}
+
+enum CreateOrderPayloadOrderStatus {
+  PENDING
+  CONFIRMED
+}
+
+type CreateOrderPayloadOrderItems {
+  productId: String!
+  quantity: Float!
+}
+```
+
+## Attaching Directives
+
+Add a third type parameter to attach directives to Query/Mutation fields:
+
+```typescript
+import { defineQuery } from "../gqlkit";
+import type { NoArgs } from "@gqlkit-ts/runtime";
+import { type AuthDirective } from "./directives.js";
+import type { User } from "./user.js";
+
+export const me = defineQuery<
+  NoArgs,
+  User,
+  [AuthDirective<{ role: ["USER"] }>]
+>((_root, _args, ctx) => ctx.currentUser);
+```
+
+Generates:
+
+```graphql
+type Query {
+  me: User! @auth(role: [USER])
+}
+```
+
+See [Directives](./directives.md) for more details on defining and using custom directives.

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/scalars.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/scalars.md
@@ -1,0 +1,199 @@
+---
+title: Defining Scalar Types
+description: gqlkit provides built-in scalar types and supports custom scalar definitions.
+---
+
+# Scalar Types
+
+gqlkit provides built-in scalar types and supports custom scalar definitions.
+
+## Built-in Scalar Types
+
+gqlkit provides branded types to explicitly specify GraphQL scalar mappings:
+
+| TypeScript type | GraphQL type |
+|-----------------|--------------|
+| `IDString`      | `ID!`        |
+| `IDNumber`      | `ID!`        |
+| `Int`           | `Int!`       |
+| `Float`         | `Float!`     |
+| `string`        | `String!`    |
+| `number`        | `Float!`     |
+| `boolean`       | `Boolean!`   |
+
+### Usage
+
+```typescript
+import { type IDString, type Int, type Float } from "@gqlkit-ts/runtime";
+
+export type User = {
+  id: IDString;       // ID!
+  age: Int;           // Int!
+  score: Float;       // Float!
+  name: string;       // String!
+  balance: number;    // Float!
+  active: boolean;    // Boolean!
+};
+```
+
+## Custom Scalars with GqlScalar
+
+Define custom scalar types using the `GqlScalar` utility type:
+
+```typescript
+// src/gqlkit/schema/scalars.ts
+import { type GqlScalar } from "@gqlkit-ts/runtime";
+
+/**
+ * ISO 8601 format date-time string
+ */
+export type DateTime = GqlScalar<"DateTime", Date>;
+```
+
+Generates:
+
+```graphql
+"""ISO 8601 format date-time string"""
+scalar DateTime
+```
+
+### GqlScalar Type Parameters
+
+`GqlScalar<Name, Base, Only?>`:
+
+| Parameter | Description |
+|-----------|-------------|
+| `Name` | The GraphQL scalar name |
+| `Base` | The TypeScript type that backs this scalar |
+| `Only` | Optional: `"input"` or `"output"` to restrict usage |
+
+### Input-only and Output-only Scalars
+
+Restrict scalar usage to input or output positions:
+
+```typescript
+import { type GqlScalar } from "@gqlkit-ts/runtime";
+
+// Input-only scalar (for input positions only)
+export type DateTimeInput = GqlScalar<"DateTime", Date, "input">;
+
+// Output-only scalar (for output positions only)
+export type DateTimeOutput = GqlScalar<"DateTime", Date | string, "output">;
+```
+
+This is useful when input and output representations differ.
+
+## Config-based Custom Scalars
+
+Alternatively, map TypeScript types to GraphQL custom scalars via config:
+
+```typescript
+// gqlkit.config.ts
+import { defineConfig } from "@gqlkit-ts/cli";
+
+export default defineConfig({
+  scalars: [
+    {
+      name: "DateTime",
+      tsType: { from: "./src/gqlkit/schema/scalars", name: "DateTime" },
+      description: "ISO 8601 datetime string",
+    },
+    {
+      name: "UUID",
+      tsType: { name: "string" },  // Global type
+      only: "input",  // Input-only scalar
+    },
+  ],
+});
+```
+
+### Config Options
+
+| Option | Description |
+|--------|-------------|
+| `name` | The GraphQL scalar name |
+| `tsType.name` | The TypeScript type name |
+| `tsType.from` | Optional: import path for the type |
+| `description` | Optional: GraphQL description |
+| `only` | Optional: `"input"` or `"output"` |
+
+## Using Custom Scalars
+
+Once defined, use custom scalars in your types:
+
+```typescript
+import type { DateTime } from "./scalars.js";
+
+export type User = {
+  id: IDString;
+  name: string;
+  createdAt: DateTime;
+  updatedAt: DateTime | null;
+};
+
+export type CreateUserInput = {
+  name: string;
+  birthDate: DateTime;
+};
+```
+
+## Registering Scalar Resolvers
+
+Custom scalars require resolver implementations to handle serialization and parsing at runtime. Pass scalar resolvers to `createResolvers`:
+
+```typescript
+import { createResolvers } from "./gqlkit/__generated__/resolvers.js";
+
+const resolvers = createResolvers({
+  scalars: {
+    DateTime: myDateTimeScalar,
+  },
+});
+```
+
+### Using graphql-scalars (Recommended)
+
+The easiest way to implement custom scalars is to use [graphql-scalars](https://the-guild.dev/graphql/scalars), which provides ready-to-use implementations for common scalar types:
+
+```typescript
+import { GraphQLDateTime } from "graphql-scalars";
+
+const resolvers = createResolvers({
+  scalars: {
+    DateTime: GraphQLDateTime,
+  },
+});
+```
+
+This approach requires no manual serialize/parse implementation.
+
+### Custom Implementation
+
+For custom behavior, create your own `GraphQLScalarType`:
+
+```typescript
+import { GraphQLScalarType, Kind } from "graphql";
+
+const DateTimeScalar = new GraphQLScalarType({
+  name: "DateTime",
+  description: "ISO 8601 date-time string",
+  serialize(value) {
+    return value instanceof Date ? value.toISOString() : value;
+  },
+  parseValue(value) {
+    return new Date(value as string);
+  },
+  parseLiteral(ast) {
+    if (ast.kind === Kind.STRING) {
+      return new Date(ast.value);
+    }
+    return null;
+  },
+});
+
+const resolvers = createResolvers({
+  scalars: {
+    DateTime: DateTimeScalar,
+  },
+});
+```

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/unions.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/unions.md
@@ -1,0 +1,297 @@
+---
+title: Defining Union Types
+description: TypeScript union types of object types are converted to GraphQL union types.
+---
+
+# Union Types
+
+TypeScript union types of object types are converted to GraphQL union types.
+
+## Basic Usage
+
+```typescript
+import type { Post } from "./Post";
+import type { Comment } from "./Comment";
+
+/**
+ * Content that can be searched
+ */
+export type SearchResult = Post | Comment;
+```
+
+Generates:
+
+```graphql
+"""Content that can be searched"""
+union SearchResult = Comment | Post
+```
+
+## Using Unions in Resolvers
+
+```typescript
+import { defineQuery } from "../gqlkit";
+import type { SearchResult } from "./types";
+
+export const search = defineQuery<{ query: string }, SearchResult[]>(
+  (_root, args, ctx) => {
+    return ctx.db.search(args.query);
+  }
+);
+```
+
+Generates:
+
+```graphql
+type Query {
+  search(query: String!): [SearchResult!]!
+}
+```
+
+## Inline Unions
+
+When a field type is an inline union of object types, gqlkit automatically generates a GraphQL Union type. The generated type name follows the convention `{ParentTypeName}{PascalCaseFieldName}`:
+
+```typescript
+import type { User } from "./User";
+import type { Post } from "./Post";
+
+export type SearchResult = {
+  id: string;
+  /**
+   * The matched item - either a User or a Post
+   */
+  item: User | Post;
+};
+```
+
+Generates:
+
+```graphql
+type SearchResult {
+  id: String!
+  """The matched item - either a User or a Post"""
+  item: SearchResultItem!
+}
+
+union SearchResultItem = Post | User
+```
+
+### Nullable Inline Unions
+
+Inline unions can be nullable:
+
+```typescript
+export type Container = {
+  id: string;
+  result: User | Post | null;
+};
+```
+
+Generates:
+
+```graphql
+type Container {
+  id: String!
+  result: ContainerResult
+}
+
+union ContainerResult = Post | User
+```
+
+### Known Type References
+
+When union members are exported types in the schema directory (`knownTypeNames`), they are preserved as references. Unknown inline object types are automatically generated:
+
+```typescript
+import type { User } from "./User"; // known type
+
+export type Activity = {
+  actor: User | { id: string; type: string }; // User is referenced, anonymous object is generated
+};
+```
+
+Generates:
+
+```graphql
+type Activity {
+  actor: ActivityActor!
+}
+
+union ActivityActor = ActivityActorAnonymous | User
+
+type ActivityActorAnonymous {
+  id: String!
+  type: String!
+}
+```
+
+### Validation
+
+Inline unions in output context must contain only object types. The following are not allowed:
+
+- Primitive types (string, number, boolean)
+- Enum types
+- Scalar types
+
+```typescript
+// These will produce errors:
+export type Invalid = {
+  value: string | number;        // Error: primitives not allowed
+  status: User | "active";       // Error: cannot mix object and enum
+};
+```
+
+## Union vs Enum
+
+- Use **Union** when each member is a distinct object type with different fields
+- Use **Enum** when you need a set of string constants
+
+```typescript
+// Union: Different object types
+export type SearchResult = Post | Comment | User;
+
+// Enum: String constants
+export type Status = "ACTIVE" | "INACTIVE" | "PENDING";
+```
+
+## Union vs Interface
+
+- Use **Union** when types share no common fields
+- Use **Interface** when types share common fields that should be queryable
+
+```typescript
+// Union: No common structure required
+export type SearchResult = Post | Comment;
+
+// Interface: Common fields enforced
+export type Node = GqlInterface<{
+  id: IDString;
+}>;
+```
+
+See [Interfaces](./interfaces.md) for more details on interface types.
+
+## Inline Union Payloads
+
+When a resolver return type is an inline union with object literals, gqlkit generates a GraphQL Union type. Each union member must have a `__typename` property with a string literal type:
+
+```typescript
+export const updateUser = defineMutation<
+  { input: UpdateUserInput },
+  | { __typename: "UpdateUserSuccess"; user: User }
+  | { __typename: "UpdateUserError"; message: string }
+>(/* ... */);
+```
+
+Generates:
+
+```graphql
+type Mutation {
+  updateUser(input: UpdateUserInput!): UpdateUserPayload!
+}
+
+union UpdateUserPayload = UpdateUserError | UpdateUserSuccess
+
+type UpdateUserSuccess {
+  user: User!
+}
+
+type UpdateUserError {
+  message: String!
+}
+```
+
+### `__typename` Requirement
+
+For inline union payloads, the `__typename` property is required and must be a string literal type:
+
+```typescript
+// ✅ OK: __typename with string literal type
+type Result =
+  | { __typename: "Success"; data: string }
+  | { __typename: "Error"; message: string };
+
+// ❌ Error: __typename missing
+type Invalid =
+  | { data: string }
+  | { message: string };
+
+// ❌ Error: __typename is not a string literal
+type AlsoInvalid =
+  | { __typename: string; data: string }
+  | { __typename: string; message: string };
+```
+
+### Automatic `__resolveType` Generation
+
+For inline union payloads, gqlkit automatically generates a `__resolveType` function that returns the `__typename` property value. You don't need to define it manually.
+
+If you need custom type resolution logic, use [defineResolveType](./abstract-resolvers.md#defineresolveType).
+
+### Mixed Union Payloads
+
+You can mix inline object literals with named types. Only inline objects require `__typename`:
+
+```typescript
+import type { User } from "./user";
+
+export const findEntity = defineQuery<
+  { id: string },
+  | User // named type - __typename determined by type
+  | { __typename: "Guest"; sessionId: string } // inline type - __typename required
+>(/* ... */);
+```
+
+Generates:
+
+```graphql
+union FindEntityPayload = Guest | User
+
+type Guest {
+  sessionId: String!
+}
+```
+
+See [Queries & Mutations](./queries-mutations.md#inline-payload-types) for more details on inline payload types.
+
+## Runtime Type Resolution
+
+When GraphQL executes a query that returns a union type, it needs to determine the concrete type at runtime.
+
+### Automatic Resolution
+
+If your union member types have `__typename` or `$typeName` fields with string literal values, gqlkit automatically generates the `resolveType` function:
+
+```typescript
+export interface User {
+  __typename: "User";
+  id: string;
+  name: string;
+}
+
+export interface Post {
+  __typename: "Post";
+  id: string;
+  title: string;
+}
+
+export type SearchResult = User | Post;
+// resolveType is automatically generated - no manual definition needed
+```
+
+### Manual Resolution
+
+For types without `__typename` or `$typeName`, use `defineResolveType`:
+
+```typescript
+import { defineResolveType } from "../gqlkit";
+
+export const searchResultResolveType = defineResolveType<SearchResult>(
+  (value) => {
+    if ("name" in value) return "User";
+    return "Post";
+  }
+);
+```
+
+See [Abstract Type Resolution](./abstract-resolvers.md) for complete documentation.

--- a/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/what-is-gqlkit.md
+++ b/eval/evals/01-crud-gqlkit-skill/.claude/skills/gqlkit-guide/references/what-is-gqlkit.md
@@ -1,0 +1,27 @@
+---
+title: What is gqlkit?
+description: Just types and functions — write TypeScript, generate GraphQL.
+---
+
+# What is gqlkit?
+
+Just types and functions — write TypeScript, generate GraphQL.
+
+## Core Concept
+
+Write types and resolvers in TypeScript → run `gqlkit gen` → get GraphQL schema AST and resolver map.
+
+## Design Principles
+
+- **Implement first**: Write types and resolvers, generate schema when ready. No edit-regenerate-implement loops.
+- **Just types and functions**: Plain TypeScript with a thin API. No complex generics, no decorators.
+- **Type-safe**: TypeScript types become GraphQL types. Resolver signatures checked at compile time.
+- **Fail fast with actionable errors**: Invalid resolver references, type mismatches, and convention violations.
+- **GraphQL-tools compatible**: Generated outputs work seamlessly with `makeExecutableSchema`.
+
+## How It Works
+
+1. Write TypeScript types and resolvers in `src/gqlkit/schema/`
+2. Run `gqlkit gen`
+3. gqlkit scans your code, builds internal type graph, and validates resolver signatures
+4. Outputs `typeDefs` (GraphQL AST) and `resolvers` map to `src/gqlkit/__generated__/`

--- a/eval/evals/01-crud-gqlkit-skill/CLAUDE.md
+++ b/eval/evals/01-crud-gqlkit-skill/CLAUDE.md
@@ -1,0 +1,3 @@
+## gqlkit
+
+When working with GraphQL schema, types, or resolvers using gqlkit, use the `gqlkit-guide` skill.

--- a/eval/evals/01-crud-gqlkit-skill/EVAL.ts
+++ b/eval/evals/01-crud-gqlkit-skill/EVAL.ts
@@ -1,0 +1,92 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  buildSchema,
+  type GraphQLObjectType,
+  type GraphQLSchema,
+} from "graphql";
+import { describe, expect, test } from "vitest";
+
+function loadSchema(): GraphQLSchema {
+  try {
+    execFileSync("pnpm", ["exec", "gqlkit", "gen"], { stdio: "pipe" });
+  } catch {
+    // Tolerated — let the SDL collection step report the missing schema.
+  }
+  const sdl = collectSdl("src");
+  if (sdl.length === 0) {
+    throw new Error(
+      "No *.graphql files found under src/ — did `gqlkit gen` run?",
+    );
+  }
+  return buildSchema(sdl);
+}
+
+function collectSdl(dir: string): string {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) continue;
+    if (entry.name === "node_modules" || entry.name === "dist") continue;
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const inner = collectSdl(p);
+      if (inner) out.push(inner);
+    } else if (entry.isFile() && entry.name.endsWith(".graphql")) {
+      out.push(readFileSync(p, "utf8"));
+    }
+  }
+  return out.join("\n");
+}
+
+function loadAgentEvalResults(): { o11y?: { filesRead?: string[] } } | null {
+  const path = "__agent_eval__/results.json";
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+describe("01-crud · gqlkit-skill", () => {
+  test("(C) typecheck passes", () => {
+    expect(() =>
+      execFileSync("npm", ["run", "typecheck"], { stdio: "pipe" }),
+    ).not.toThrow();
+  });
+
+  test("(D-1) schema builds", () => {
+    expect(() => loadSchema()).not.toThrow();
+  });
+
+  test("(D-2) declared operations exist", () => {
+    const schema = loadSchema();
+    const queryFields = schema.getQueryType()?.getFields() ?? {};
+    const mutationFields = schema.getMutationType()?.getFields() ?? {};
+    for (const name of ["users", "user", "posts"]) {
+      expect(Object.keys(queryFields)).toContain(name);
+    }
+    for (const name of [
+      "createUser",
+      "createPost",
+      "updatePost",
+      "deletePost",
+    ]) {
+      expect(Object.keys(mutationFields)).toContain(name);
+    }
+  });
+
+  test("(F) User.email is not exposed", () => {
+    const schema = loadSchema();
+    const User = schema.getType("User") as GraphQLObjectType | null;
+    expect(User, "User type must exist").not.toBeNull();
+    expect(Object.keys(User!.getFields())).not.toContain("email");
+  });
+
+  test("(A) agent consulted the gqlkit-guide skill", () => {
+    const results = loadAgentEvalResults();
+    if (results === null) return;
+    const filesRead = results.o11y?.filesRead ?? [];
+    expect(
+      filesRead.some((f) => f.includes(".claude/skills/gqlkit-guide")),
+      "agent should Read at least one file under .claude/skills/gqlkit-guide/ before coding",
+    ).toBe(true);
+  });
+});

--- a/eval/evals/01-crud-gqlkit-skill/PROMPT.md
+++ b/eval/evals/01-crud-gqlkit-skill/PROMPT.md
@@ -1,0 +1,33 @@
+# 01-crud
+
+Implement a GraphQL API for a tiny `User` / `Post` system in TypeScript.
+
+## Domain
+
+```ts
+// Backing types — already provided in src/db/schema.ts
+type DbUser = { id: string; name: string; email: string; createdAt: Date };
+type DbPost = {
+  id: string; title: string; body: string; authorId: string;
+  internalNotes: string;
+  priority: "low" | "medium" | "high";
+  createdAt: Date;
+};
+```
+
+GraphQL surface:
+
+- `Query.users: [User!]!`
+- `Query.user(id: ID!): User`
+- `Query.posts: [Post!]!`
+- `Mutation.createUser(input: CreateUserInput!): User!`
+- `Mutation.createPost(input: CreatePostInput!): Post!`
+- `Mutation.updatePost(input: UpdatePostInput!): Post!`
+- `Mutation.deletePost(id: ID!): Boolean!`
+
+`src/db/` also exposes a `Context` type used as the GraphQL resolver context.
+
+## Constraints
+
+- **`User.email` MUST NOT be exposed** in the GraphQL schema (sensitive).
+- `Post.internalNotes` is irrelevant — leave it off GraphQL entirely.

--- a/eval/evals/01-crud-gqlkit-skill/package.json
+++ b/eval/evals/01-crud-gqlkit-skill/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "eval-01-crud-gqlkit-skill",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "gen": "gqlkit gen",
+    "print-schema": "tsx scripts/print-schema.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@gqlkit-ts/runtime": "^0.3.0",
+    "graphql": "16.14.0"
+  },
+  "devDependencies": {
+    "@gqlkit-ts/cli": "^0.7.2",
+    "@types/node": "^24.0.0",
+    "tsx": "^4.22.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.6"
+  }
+}

--- a/eval/evals/01-crud-gqlkit-skill/src/db/db-schema.ts
+++ b/eval/evals/01-crud-gqlkit-skill/src/db/db-schema.ts
@@ -1,0 +1,49 @@
+/**
+ * Source-of-truth backing schema used across every eval.
+ *
+ * Modeled after a Drizzle ORM schema so agents see a familiar shape.
+ * Each eval's `src/db/schema.ts` is generated from this file via
+ * `pnpm sync` — never edit the copies directly.
+ */
+
+export type DbUser = {
+  id: string;
+  name: string;
+  /** Sensitive: must NEVER appear in the GraphQL schema. */
+  email: string;
+  createdAt: Date;
+};
+
+export type DbPost = {
+  id: string;
+  title: string;
+  body: string;
+  authorId: string;
+  /** Internal moderation notes — must NEVER appear in the GraphQL schema. */
+  internalNotes: string;
+  /** Persisted as a string literal union; expose as a GraphQL enum. */
+  priority: "low" | "medium" | "high";
+  createdAt: Date;
+};
+
+// Approximate Drizzle table objects. They are intentionally untyped against
+// `drizzle-orm` so this fixture installs in the sandbox without pulling drizzle.
+// Treat them as opaque values whose only purpose is to type-check `DbUser` /
+// `DbPost` derivations via the exported types above.
+export const usersTable = {
+  _: "users_table_marker" as const,
+  columns: ["id", "name", "email", "createdAt"] as const,
+};
+
+export const postsTable = {
+  _: "posts_table_marker" as const,
+  columns: [
+    "id",
+    "title",
+    "body",
+    "authorId",
+    "internalNotes",
+    "priority",
+    "createdAt",
+  ] as const,
+};

--- a/eval/evals/01-crud-gqlkit-skill/src/db/loaders.ts
+++ b/eval/evals/01-crud-gqlkit-skill/src/db/loaders.ts
@@ -1,0 +1,55 @@
+/**
+ * DataLoader-shaped stubs the agent must wire through GraphQL context.
+ *
+ * The bodies throw so callers can't accidentally pass tests by bypassing
+ * the loader plumbing. EVAL.ts checks the generated resolvers actually
+ * invoke these loaders.
+ */
+
+import type { DbPost, DbUser } from "./db-schema.js";
+
+export interface Loader<K, V> {
+  load(key: K): Promise<V>;
+  loadMany(keys: readonly K[]): Promise<V[]>;
+}
+
+export type UserByIdLoader = Loader<string, DbUser>;
+export type PostsByUserIdLoader = Loader<string, DbPost[]>;
+
+export function createUserByIdLoader(): UserByIdLoader {
+  return {
+    load() {
+      throw new Error(
+        "UserByIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+    loadMany() {
+      throw new Error(
+        "UserByIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+  };
+}
+
+export function createPostsByUserIdLoader(): PostsByUserIdLoader {
+  return {
+    load() {
+      throw new Error(
+        "PostsByUserIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+    loadMany() {
+      throw new Error(
+        "PostsByUserIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+  };
+}
+
+export interface Context {
+  loaders: {
+    userById: UserByIdLoader;
+    postsByUserId: PostsByUserIdLoader;
+  };
+  viewerId: string | null;
+}

--- a/eval/evals/01-crud-gqlkit-skill/tsconfig.json
+++ b/eval/evals/01-crud-gqlkit-skill/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "outDir": "dist"
+  },
+  "include": ["src", "scripts"]
+}

--- a/eval/evals/01-crud-pothos/EVAL.ts
+++ b/eval/evals/01-crud-pothos/EVAL.ts
@@ -1,0 +1,76 @@
+import { execFileSync } from "node:child_process";
+import type { GraphQLObjectType, GraphQLSchema } from "graphql";
+import { describe, expect, test } from "vitest";
+
+/**
+ * Pothos agents usually export a `GraphQLSchema` from one of a few common
+ * locations. Try them in order; surface the first hit.
+ */
+async function loadSchema(): Promise<GraphQLSchema> {
+  const candidates = [
+    "./src/schema/index.ts",
+    "./src/schema.ts",
+    "./src/index.ts",
+    "./src/schema/builder.ts",
+    "./src/builder.ts",
+  ];
+  const isSchema = (v: unknown): v is GraphQLSchema =>
+    !!v && typeof (v as { getQueryType?: unknown }).getQueryType === "function";
+
+  const tried: string[] = [];
+  for (const path of candidates) {
+    try {
+      const mod: Record<string, unknown> = await import(path);
+      if (isSchema(mod.schema)) return mod.schema;
+      if (isSchema(mod.default)) return mod.default;
+      const builder = mod.builder as
+        | { toSchema?: () => GraphQLSchema }
+        | undefined;
+      if (builder && typeof builder.toSchema === "function") {
+        return builder.toSchema();
+      }
+      tried.push(`${path} (no schema/default/builder export)`);
+    } catch (e) {
+      tried.push(`${path} (${(e as Error).message})`);
+    }
+  }
+  throw new Error(
+    `Could not load a GraphQL schema. Tried:\n  - ${tried.join("\n  - ")}`,
+  );
+}
+
+describe("01-crud · pothos", () => {
+  test("(C) typecheck passes", () => {
+    expect(() =>
+      execFileSync("npm", ["run", "typecheck"], { stdio: "pipe" }),
+    ).not.toThrow();
+  });
+
+  test("(D-1) schema builds", async () => {
+    await loadSchema();
+  });
+
+  test("(D-2) declared operations exist", async () => {
+    const schema = await loadSchema();
+    const queryFields = schema.getQueryType()?.getFields() ?? {};
+    const mutationFields = schema.getMutationType()?.getFields() ?? {};
+    for (const name of ["users", "user", "posts"]) {
+      expect(Object.keys(queryFields)).toContain(name);
+    }
+    for (const name of [
+      "createUser",
+      "createPost",
+      "updatePost",
+      "deletePost",
+    ]) {
+      expect(Object.keys(mutationFields)).toContain(name);
+    }
+  });
+
+  test("(F) User.email is not exposed", async () => {
+    const schema = await loadSchema();
+    const User = schema.getType("User") as GraphQLObjectType | null;
+    expect(User, "User type must exist").not.toBeNull();
+    expect(Object.keys(User!.getFields())).not.toContain("email");
+  });
+});

--- a/eval/evals/01-crud-pothos/PROMPT.md
+++ b/eval/evals/01-crud-pothos/PROMPT.md
@@ -1,0 +1,34 @@
+# 01-crud — Pothos
+
+Implement a GraphQL API for a tiny `User` / `Post` system in TypeScript using
+**[Pothos](https://pothos-graphql.dev/)** (`@pothos/core`).
+
+## Domain
+
+```ts
+// Backing types — already provided in src/db/schema.ts
+type DbUser = { id: string; name: string; email: string; createdAt: Date };
+type DbPost = {
+  id: string; title: string; body: string; authorId: string;
+  internalNotes: string;
+  priority: "low" | "medium" | "high";
+  createdAt: Date;
+};
+```
+
+GraphQL surface:
+
+- `Query.users: [User!]!`
+- `Query.user(id: ID!): User`
+- `Query.posts: [Post!]!`
+- `Mutation.createUser(input: CreateUserInput!): User!`
+- `Mutation.createPost(input: CreatePostInput!): Post!`
+- `Mutation.updatePost(input: UpdatePostInput!): Post!`
+- `Mutation.deletePost(id: ID!): Boolean!`
+
+`src/db/` also exposes a `Context` type used as the GraphQL resolver context.
+
+## Constraints
+
+- **`User.email` MUST NOT be exposed** in the GraphQL schema (sensitive).
+- `Post.internalNotes` is irrelevant — leave it off GraphQL entirely.

--- a/eval/evals/01-crud-pothos/package.json
+++ b/eval/evals/01-crud-pothos/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "eval-01-crud-pothos",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "print-schema": "tsx scripts/print-schema.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@pothos/core": "^4.0.0",
+    "graphql": "16.14.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "tsx": "^4.22.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.6"
+  }
+}

--- a/eval/evals/01-crud-pothos/src/db/db-schema.ts
+++ b/eval/evals/01-crud-pothos/src/db/db-schema.ts
@@ -1,0 +1,49 @@
+/**
+ * Source-of-truth backing schema used across every eval.
+ *
+ * Modeled after a Drizzle ORM schema so agents see a familiar shape.
+ * Each eval's `src/db/schema.ts` is generated from this file via
+ * `pnpm sync` — never edit the copies directly.
+ */
+
+export type DbUser = {
+  id: string;
+  name: string;
+  /** Sensitive: must NEVER appear in the GraphQL schema. */
+  email: string;
+  createdAt: Date;
+};
+
+export type DbPost = {
+  id: string;
+  title: string;
+  body: string;
+  authorId: string;
+  /** Internal moderation notes — must NEVER appear in the GraphQL schema. */
+  internalNotes: string;
+  /** Persisted as a string literal union; expose as a GraphQL enum. */
+  priority: "low" | "medium" | "high";
+  createdAt: Date;
+};
+
+// Approximate Drizzle table objects. They are intentionally untyped against
+// `drizzle-orm` so this fixture installs in the sandbox without pulling drizzle.
+// Treat them as opaque values whose only purpose is to type-check `DbUser` /
+// `DbPost` derivations via the exported types above.
+export const usersTable = {
+  _: "users_table_marker" as const,
+  columns: ["id", "name", "email", "createdAt"] as const,
+};
+
+export const postsTable = {
+  _: "posts_table_marker" as const,
+  columns: [
+    "id",
+    "title",
+    "body",
+    "authorId",
+    "internalNotes",
+    "priority",
+    "createdAt",
+  ] as const,
+};

--- a/eval/evals/01-crud-pothos/src/db/loaders.ts
+++ b/eval/evals/01-crud-pothos/src/db/loaders.ts
@@ -1,0 +1,55 @@
+/**
+ * DataLoader-shaped stubs the agent must wire through GraphQL context.
+ *
+ * The bodies throw so callers can't accidentally pass tests by bypassing
+ * the loader plumbing. EVAL.ts checks the generated resolvers actually
+ * invoke these loaders.
+ */
+
+import type { DbPost, DbUser } from "./db-schema.js";
+
+export interface Loader<K, V> {
+  load(key: K): Promise<V>;
+  loadMany(keys: readonly K[]): Promise<V[]>;
+}
+
+export type UserByIdLoader = Loader<string, DbUser>;
+export type PostsByUserIdLoader = Loader<string, DbPost[]>;
+
+export function createUserByIdLoader(): UserByIdLoader {
+  return {
+    load() {
+      throw new Error(
+        "UserByIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+    loadMany() {
+      throw new Error(
+        "UserByIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+  };
+}
+
+export function createPostsByUserIdLoader(): PostsByUserIdLoader {
+  return {
+    load() {
+      throw new Error(
+        "PostsByUserIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+    loadMany() {
+      throw new Error(
+        "PostsByUserIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+  };
+}
+
+export interface Context {
+  loaders: {
+    userById: UserByIdLoader;
+    postsByUserId: PostsByUserIdLoader;
+  };
+  viewerId: string | null;
+}

--- a/eval/evals/01-crud-pothos/tsconfig.json
+++ b/eval/evals/01-crud-pothos/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "outDir": "dist"
+  },
+  "include": ["src", "scripts"]
+}

--- a/eval/evals/02-relation-codegen/EVAL.ts
+++ b/eval/evals/02-relation-codegen/EVAL.ts
@@ -1,0 +1,112 @@
+import { execFileSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  buildSchema,
+  type GraphQLObjectType,
+  type GraphQLSchema,
+} from "graphql";
+import { describe, expect, test } from "vitest";
+
+function loadSchema(): GraphQLSchema {
+  try {
+    execFileSync("pnpm", ["exec", "graphql-codegen"], { stdio: "pipe" });
+  } catch {
+    // Tolerated — let SDL collection report the missing schema.
+  }
+  const sdl = collectSdl("src");
+  if (sdl.length === 0) {
+    throw new Error(
+      "No *.graphql files found under src/ — agent did not produce SDL",
+    );
+  }
+  return buildSchema(sdl);
+}
+
+function collectSdl(dir: string): string {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) continue;
+    if (entry.name === "node_modules" || entry.name === "dist") continue;
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const inner = collectSdl(p);
+      if (inner) out.push(inner);
+    } else if (entry.isFile() && entry.name.endsWith(".graphql")) {
+      out.push(readFileSync(p, "utf8"));
+    }
+  }
+  return out.join("\n");
+}
+
+function readAllAgentSource(): string {
+  const skip = new Set([
+    "node_modules",
+    "dist",
+    "__generated__",
+    "__agent_eval__",
+  ]);
+  const buf: string[] = [];
+  function walk(dir: string): void {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (skip.has(entry.name)) continue;
+      if (entry.name.startsWith(".")) continue;
+      if (entry.name === "EVAL.ts" || entry.name === "EVAL.tsx") continue;
+      const p = join(dir, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else if (entry.isFile() && /\.(ts|tsx|graphql)$/.test(entry.name)) {
+        buf.push(readFileSync(p, "utf8"));
+      }
+    }
+  }
+  walk("src");
+  return buf.join("\n");
+}
+
+describe("02-relation · codegen", () => {
+  test("(C) typecheck passes", () => {
+    expect(() =>
+      execFileSync("npm", ["run", "typecheck"], { stdio: "pipe" }),
+    ).not.toThrow();
+  });
+
+  test("(D-1) schema builds", () => {
+    expect(() => loadSchema()).not.toThrow();
+  });
+
+  test("(D-2) relations declared on User and Post", () => {
+    const schema = loadSchema();
+    const User = schema.getType("User") as GraphQLObjectType | null;
+    const Post = schema.getType("Post") as GraphQLObjectType | null;
+    expect(User, "User type").not.toBeNull();
+    expect(Post, "Post type").not.toBeNull();
+    expect(Object.keys(User!.getFields())).toContain("posts");
+    expect(Object.keys(Post!.getFields())).toContain("author");
+  });
+
+  test("(F) User.email is not exposed", () => {
+    const schema = loadSchema();
+    const User = schema.getType("User") as GraphQLObjectType | null;
+    expect(Object.keys(User!.getFields())).not.toContain("email");
+  });
+
+  test("(B) relation resolvers use DataLoader", () => {
+    const code = readAllAgentSource();
+    expect(
+      /postsByUserId(Loader)?\.load(Many)?\(/.test(code),
+      "User.posts resolver should call ctx.loaders.postsByUserId.load(...) or .loadMany(...)",
+    ).toBe(true);
+    expect(
+      /userById(Loader)?\.load(Many)?\(/.test(code),
+      "Post.author resolver should call ctx.loaders.userById.load(...)",
+    ).toBe(true);
+  });
+
+  test("(B) no obvious N+1 fanout pattern", () => {
+    const code = readAllAgentSource();
+    expect(
+      /Promise\.all\([\s\S]{0,200}\.find(ById)?\(/.test(code),
+      "Found a `Promise.all(... .find(...))` shape — likely N+1",
+    ).toBe(false);
+  });
+});

--- a/eval/evals/02-relation-codegen/PROMPT.md
+++ b/eval/evals/02-relation-codegen/PROMPT.md
@@ -1,0 +1,29 @@
+# 02-relation — graphql-codegen
+
+Extend the 01-crud schema with relations between `User` and `Post`, implemented
+using **[graphql-codegen](https://the-guild.dev/graphql/codegen)**.
+
+## Domain
+
+Backing types (provided in `src/db/schema.ts`) are unchanged. `src/db/` also
+exposes a `Context` type used as the GraphQL resolver context.
+
+## GraphQL surface
+
+All operations from 01-crud, **plus**:
+
+- `User.posts: [Post!]!`
+- `Post.author: User!`
+
+The reference query the API must support:
+
+```graphql
+query {
+  users { id name posts { id title } }
+}
+```
+
+## Constraints
+
+- **`User.email` MUST NOT be exposed**.
+- `Post.internalNotes` is irrelevant — leave it off GraphQL entirely.

--- a/eval/evals/02-relation-codegen/package.json
+++ b/eval/evals/02-relation-codegen/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "eval-02-relation-codegen",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "codegen": "graphql-codegen",
+    "print-schema": "tsx scripts/print-schema.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "graphql": "16.14.0"
+  },
+  "devDependencies": {
+    "@eddeee888/gcg-typescript-resolver-files": "^0.13.0",
+    "@graphql-codegen/cli": "^5.0.0",
+    "@graphql-codegen/typescript": "^4.0.0",
+    "@graphql-codegen/typescript-resolvers": "^4.0.0",
+    "@types/node": "^24.0.0",
+    "tsx": "^4.22.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.6"
+  }
+}

--- a/eval/evals/02-relation-codegen/src/db/db-schema.ts
+++ b/eval/evals/02-relation-codegen/src/db/db-schema.ts
@@ -1,0 +1,49 @@
+/**
+ * Source-of-truth backing schema used across every eval.
+ *
+ * Modeled after a Drizzle ORM schema so agents see a familiar shape.
+ * Each eval's `src/db/schema.ts` is generated from this file via
+ * `pnpm sync` — never edit the copies directly.
+ */
+
+export type DbUser = {
+  id: string;
+  name: string;
+  /** Sensitive: must NEVER appear in the GraphQL schema. */
+  email: string;
+  createdAt: Date;
+};
+
+export type DbPost = {
+  id: string;
+  title: string;
+  body: string;
+  authorId: string;
+  /** Internal moderation notes — must NEVER appear in the GraphQL schema. */
+  internalNotes: string;
+  /** Persisted as a string literal union; expose as a GraphQL enum. */
+  priority: "low" | "medium" | "high";
+  createdAt: Date;
+};
+
+// Approximate Drizzle table objects. They are intentionally untyped against
+// `drizzle-orm` so this fixture installs in the sandbox without pulling drizzle.
+// Treat them as opaque values whose only purpose is to type-check `DbUser` /
+// `DbPost` derivations via the exported types above.
+export const usersTable = {
+  _: "users_table_marker" as const,
+  columns: ["id", "name", "email", "createdAt"] as const,
+};
+
+export const postsTable = {
+  _: "posts_table_marker" as const,
+  columns: [
+    "id",
+    "title",
+    "body",
+    "authorId",
+    "internalNotes",
+    "priority",
+    "createdAt",
+  ] as const,
+};

--- a/eval/evals/02-relation-codegen/src/db/loaders.ts
+++ b/eval/evals/02-relation-codegen/src/db/loaders.ts
@@ -1,0 +1,55 @@
+/**
+ * DataLoader-shaped stubs the agent must wire through GraphQL context.
+ *
+ * The bodies throw so callers can't accidentally pass tests by bypassing
+ * the loader plumbing. EVAL.ts checks the generated resolvers actually
+ * invoke these loaders.
+ */
+
+import type { DbPost, DbUser } from "./db-schema.js";
+
+export interface Loader<K, V> {
+  load(key: K): Promise<V>;
+  loadMany(keys: readonly K[]): Promise<V[]>;
+}
+
+export type UserByIdLoader = Loader<string, DbUser>;
+export type PostsByUserIdLoader = Loader<string, DbPost[]>;
+
+export function createUserByIdLoader(): UserByIdLoader {
+  return {
+    load() {
+      throw new Error(
+        "UserByIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+    loadMany() {
+      throw new Error(
+        "UserByIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+  };
+}
+
+export function createPostsByUserIdLoader(): PostsByUserIdLoader {
+  return {
+    load() {
+      throw new Error(
+        "PostsByUserIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+    loadMany() {
+      throw new Error(
+        "PostsByUserIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+  };
+}
+
+export interface Context {
+  loaders: {
+    userById: UserByIdLoader;
+    postsByUserId: PostsByUserIdLoader;
+  };
+  viewerId: string | null;
+}

--- a/eval/evals/02-relation-codegen/tsconfig.json
+++ b/eval/evals/02-relation-codegen/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "outDir": "dist"
+  },
+  "include": ["src", "scripts"]
+}

--- a/eval/evals/02-relation-gqlkit-plain/EVAL.ts
+++ b/eval/evals/02-relation-gqlkit-plain/EVAL.ts
@@ -1,0 +1,112 @@
+import { execFileSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  buildSchema,
+  type GraphQLObjectType,
+  type GraphQLSchema,
+} from "graphql";
+import { describe, expect, test } from "vitest";
+
+function loadSchema(): GraphQLSchema {
+  try {
+    execFileSync("pnpm", ["exec", "gqlkit", "gen"], { stdio: "pipe" });
+  } catch {
+    // Tolerated — let SDL collection report the missing schema.
+  }
+  const sdl = collectSdl("src");
+  if (sdl.length === 0) {
+    throw new Error(
+      "No *.graphql files found under src/ — did `gqlkit gen` run?",
+    );
+  }
+  return buildSchema(sdl);
+}
+
+function collectSdl(dir: string): string {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) continue;
+    if (entry.name === "node_modules" || entry.name === "dist") continue;
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const inner = collectSdl(p);
+      if (inner) out.push(inner);
+    } else if (entry.isFile() && entry.name.endsWith(".graphql")) {
+      out.push(readFileSync(p, "utf8"));
+    }
+  }
+  return out.join("\n");
+}
+
+function readAllAgentSource(): string {
+  const skip = new Set([
+    "node_modules",
+    "dist",
+    "__generated__",
+    "__agent_eval__",
+  ]);
+  const buf: string[] = [];
+  function walk(dir: string): void {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (skip.has(entry.name)) continue;
+      if (entry.name.startsWith(".")) continue;
+      if (entry.name === "EVAL.ts" || entry.name === "EVAL.tsx") continue;
+      const p = join(dir, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else if (entry.isFile() && /\.(ts|tsx|graphql)$/.test(entry.name)) {
+        buf.push(readFileSync(p, "utf8"));
+      }
+    }
+  }
+  walk("src");
+  return buf.join("\n");
+}
+
+describe("02-relation · gqlkit-plain", () => {
+  test("(C) typecheck passes", () => {
+    expect(() =>
+      execFileSync("npm", ["run", "typecheck"], { stdio: "pipe" }),
+    ).not.toThrow();
+  });
+
+  test("(D-1) schema builds", () => {
+    expect(() => loadSchema()).not.toThrow();
+  });
+
+  test("(D-2) relations declared on User and Post", () => {
+    const schema = loadSchema();
+    const User = schema.getType("User") as GraphQLObjectType | null;
+    const Post = schema.getType("Post") as GraphQLObjectType | null;
+    expect(User, "User type").not.toBeNull();
+    expect(Post, "Post type").not.toBeNull();
+    expect(Object.keys(User!.getFields())).toContain("posts");
+    expect(Object.keys(Post!.getFields())).toContain("author");
+  });
+
+  test("(F) User.email is not exposed", () => {
+    const schema = loadSchema();
+    const User = schema.getType("User") as GraphQLObjectType | null;
+    expect(Object.keys(User!.getFields())).not.toContain("email");
+  });
+
+  test("(B) relation resolvers use DataLoader", () => {
+    const code = readAllAgentSource();
+    expect(
+      /postsByUserId(Loader)?\.load(Many)?\(/.test(code),
+      "User.posts resolver should call ctx.loaders.postsByUserId.load(...) or .loadMany(...)",
+    ).toBe(true);
+    expect(
+      /userById(Loader)?\.load(Many)?\(/.test(code),
+      "Post.author resolver should call ctx.loaders.userById.load(...)",
+    ).toBe(true);
+  });
+
+  test("(B) no obvious N+1 fanout pattern", () => {
+    const code = readAllAgentSource();
+    expect(
+      /Promise\.all\([\s\S]{0,200}\.find(ById)?\(/.test(code),
+      "Found a `Promise.all(... .find(...))` shape — likely N+1",
+    ).toBe(false);
+  });
+});

--- a/eval/evals/02-relation-gqlkit-plain/PROMPT.md
+++ b/eval/evals/02-relation-gqlkit-plain/PROMPT.md
@@ -1,0 +1,29 @@
+# 02-relation — gqlkit (plain)
+
+Extend the 01-crud schema with relations between `User` and `Post`, implemented
+using **[gqlkit](https://www.npmjs.com/package/@gqlkit-ts/cli)**
+(`@gqlkit-ts/cli` and `@gqlkit-ts/runtime`).
+
+## Domain
+
+Backing types (provided in `src/db/schema.ts`) are unchanged. `src/db/` also
+exposes a `Context` type used as the GraphQL resolver context.
+
+## GraphQL surface
+
+All operations from 01-crud, **plus**:
+
+- `User.posts: [Post!]!`
+- `Post.author: User!`
+
+Reference query:
+
+```graphql
+query {
+  users { id name posts { id title } }
+}
+```
+
+## Constraints
+
+- **`User.email` MUST NOT be exposed**.

--- a/eval/evals/02-relation-gqlkit-plain/package.json
+++ b/eval/evals/02-relation-gqlkit-plain/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "eval-02-relation-gqlkit-plain",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "gen": "gqlkit gen",
+    "print-schema": "tsx scripts/print-schema.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@gqlkit-ts/runtime": "^0.3.0",
+    "graphql": "16.14.0"
+  },
+  "devDependencies": {
+    "@gqlkit-ts/cli": "^0.7.2",
+    "@types/node": "^24.0.0",
+    "tsx": "^4.22.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.6"
+  }
+}

--- a/eval/evals/02-relation-gqlkit-plain/src/db/db-schema.ts
+++ b/eval/evals/02-relation-gqlkit-plain/src/db/db-schema.ts
@@ -1,0 +1,49 @@
+/**
+ * Source-of-truth backing schema used across every eval.
+ *
+ * Modeled after a Drizzle ORM schema so agents see a familiar shape.
+ * Each eval's `src/db/schema.ts` is generated from this file via
+ * `pnpm sync` — never edit the copies directly.
+ */
+
+export type DbUser = {
+  id: string;
+  name: string;
+  /** Sensitive: must NEVER appear in the GraphQL schema. */
+  email: string;
+  createdAt: Date;
+};
+
+export type DbPost = {
+  id: string;
+  title: string;
+  body: string;
+  authorId: string;
+  /** Internal moderation notes — must NEVER appear in the GraphQL schema. */
+  internalNotes: string;
+  /** Persisted as a string literal union; expose as a GraphQL enum. */
+  priority: "low" | "medium" | "high";
+  createdAt: Date;
+};
+
+// Approximate Drizzle table objects. They are intentionally untyped against
+// `drizzle-orm` so this fixture installs in the sandbox without pulling drizzle.
+// Treat them as opaque values whose only purpose is to type-check `DbUser` /
+// `DbPost` derivations via the exported types above.
+export const usersTable = {
+  _: "users_table_marker" as const,
+  columns: ["id", "name", "email", "createdAt"] as const,
+};
+
+export const postsTable = {
+  _: "posts_table_marker" as const,
+  columns: [
+    "id",
+    "title",
+    "body",
+    "authorId",
+    "internalNotes",
+    "priority",
+    "createdAt",
+  ] as const,
+};

--- a/eval/evals/02-relation-gqlkit-plain/src/db/loaders.ts
+++ b/eval/evals/02-relation-gqlkit-plain/src/db/loaders.ts
@@ -1,0 +1,55 @@
+/**
+ * DataLoader-shaped stubs the agent must wire through GraphQL context.
+ *
+ * The bodies throw so callers can't accidentally pass tests by bypassing
+ * the loader plumbing. EVAL.ts checks the generated resolvers actually
+ * invoke these loaders.
+ */
+
+import type { DbPost, DbUser } from "./db-schema.js";
+
+export interface Loader<K, V> {
+  load(key: K): Promise<V>;
+  loadMany(keys: readonly K[]): Promise<V[]>;
+}
+
+export type UserByIdLoader = Loader<string, DbUser>;
+export type PostsByUserIdLoader = Loader<string, DbPost[]>;
+
+export function createUserByIdLoader(): UserByIdLoader {
+  return {
+    load() {
+      throw new Error(
+        "UserByIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+    loadMany() {
+      throw new Error(
+        "UserByIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+  };
+}
+
+export function createPostsByUserIdLoader(): PostsByUserIdLoader {
+  return {
+    load() {
+      throw new Error(
+        "PostsByUserIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+    loadMany() {
+      throw new Error(
+        "PostsByUserIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+  };
+}
+
+export interface Context {
+  loaders: {
+    userById: UserByIdLoader;
+    postsByUserId: PostsByUserIdLoader;
+  };
+  viewerId: string | null;
+}

--- a/eval/evals/02-relation-gqlkit-plain/tsconfig.json
+++ b/eval/evals/02-relation-gqlkit-plain/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "outDir": "dist"
+  },
+  "include": ["src", "scripts"]
+}

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/SKILL.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: gqlkit-guide
+description: Use when the user asks about "gqlkit", "gqlkit usage", "gqlkit schema definition", "gqlkit configuration", "gqlkit resolvers", "GraphQL code generation with gqlkit", or needs guidance on gqlkit conventions, type definitions, or integration with GraphQL servers or ORMs.
+---
+
+# gqlkit Guide
+
+gqlkit generates GraphQL schema and resolver maps from TypeScript types and functions.
+
+## How it works
+
+1. Write TypeScript types in `src/gqlkit/schema/` → become GraphQL types
+2. Write resolver functions using `defineQuery`, `defineMutation`, `defineField` → become GraphQL resolvers
+3. Run `gqlkit gen` → outputs `typeDefs` and `resolvers` to `src/gqlkit/__generated__/`
+
+## Design principles
+
+- **Implement first**: Write types and resolvers, generate schema when ready. No edit-regenerate-implement loops.
+- **Just types and functions**: Plain TypeScript with a thin API. No decorators, no complex generics.
+- **Type-safe**: TypeScript types become GraphQL types. Resolver signatures checked at compile time.
+
+## How to Use This Skill
+
+Read [references/index.md](references/index.md) first. It contains the complete documentation index with all available topics.
+
+Navigate to specific documentation files based on user needs as indicated in the index.

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/coding-agents.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/coding-agents.md
@@ -1,0 +1,64 @@
+---
+title: Coding Agents
+description: Set up AI coding agents like Claude Code and Codex to understand gqlkit conventions. (skip if reading via `gqlkit-guide` skill)
+---
+
+# Coding Agents
+
+gqlkit provides built-in support for AI coding agents like [Claude Code](https://claude.ai/code) and [OpenAI Codex](https://openai.com/index/openai-codex/). The `gqlkit docs` command generates skill files that help these tools understand gqlkit conventions and provide better assistance.
+
+## Setup
+
+Run the following command in your project root:
+
+```sh filename="npm"
+npm exec gqlkit docs
+```
+
+```sh filename="pnpm"
+pnpm gqlkit docs
+```
+
+```sh filename="yarn"
+yarn gqlkit docs
+```
+
+The command auto-detects your environment based on existing files (`CLAUDE.md`, `.claude/`, `AGENTS.md`, `.codex/`) and generates the appropriate files.
+
+## Generated Files
+
+### Claude Code
+
+When Claude Code environment is detected (or `--claude` flag is used):
+
+- `.claude/skills/gqlkit-guide/SKILL.md` - Skill definition with gqlkit documentation
+- `.claude/skills/gqlkit-guide/references/` - Symlink to detailed documentation
+- `CLAUDE.md` - Updated with gqlkit section (created if not exists)
+
+### OpenAI Codex
+
+When Codex environment is detected (or `--codex` flag is used):
+
+- `.codex/skills/gqlkit-guide/SKILL.md` - Skill definition with gqlkit documentation
+- `.codex/skills/gqlkit-guide/references/` - Symlink to detailed documentation
+- `AGENTS.md` - Updated with gqlkit section (created if not exists)
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--output <dir>` | Output directory (default: current directory) |
+| `--claude` | Generate Claude Code files explicitly |
+| `--codex` | Generate Codex files explicitly |
+
+## How It Works
+
+The generated skill files follow the [Agent Skills](https://agentskills.io/) specification. When you ask the coding agent about gqlkit, it will:
+
+1. Recognize gqlkit-related questions from the skill description
+2. Read the bundled documentation to understand gqlkit conventions
+3. Provide accurate guidance based on the latest documentation
+
+## Keeping Skills Updated
+
+Re-run `gqlkit docs` after updating gqlkit to ensure the skill files reflect the latest documentation.

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/configuration.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/configuration.md
@@ -1,0 +1,182 @@
+---
+title: Configuration
+description: Configure gqlkit via gqlkit.config.ts in your project root.
+---
+
+# Configuration
+
+gqlkit can be configured via `gqlkit.config.ts` in your project root.
+
+## CLI Options
+
+The `gqlkit gen` command accepts the following options:
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--config <path>` | `-c` | Path to config file (default: `gqlkit.config.ts`) |
+| `--cwd <path>` | | Working directory for code generation |
+
+### Using Multiple Config Files
+
+You can use different config files for different GraphQL schemas:
+
+```sh
+# Generate with default config (gqlkit.config.ts)
+gqlkit gen
+
+# Generate with a specific config file
+gqlkit gen --config gqlkit.public.config.ts
+gqlkit gen -c gqlkit.admin.config.ts
+```
+
+This is useful when you need to generate multiple GraphQL schemas from the same project, such as separate public and internal APIs.
+
+## Basic Configuration
+
+```ts
+// gqlkit.config.ts
+import { defineConfig } from "@gqlkit-ts/cli";
+
+export default defineConfig({
+  // Source directory (default: "src/gqlkit/schema")
+  sourceDir: "src/gqlkit/schema",
+
+  // Glob patterns to exclude from scanning
+  sourceIgnoreGlobs: ["**/*.test.ts"],
+
+  // Custom scalar mappings (config-based approach)
+  scalars: [
+    {
+      name: "DateTime",
+      tsType: { from: "./src/gqlkit/schema/scalars", name: "DateTime" },
+      description: "ISO 8601 datetime",
+    },
+    {
+      name: "UUID",
+      tsType: { name: "string" }, // Global type
+    },
+  ],
+
+  // Output paths
+  output: {
+    typeDefsPath: "src/gqlkit/__generated__/typeDefs.ts",
+    resolversPath: "src/gqlkit/__generated__/resolvers.ts",
+    schemaPath: "src/gqlkit/__generated__/schema.graphql",
+    // Set to null to disable output:
+    // schemaPath: null,
+    // Import extension in generated files (default: "js")
+    // importExtension: "none", // for bundlers
+  },
+
+  // Hooks
+  hooks: {
+    // Run after all files are written (e.g., formatting)
+    afterAllFileWrite: "prettier --write",
+    // Or multiple commands:
+    // afterAllFileWrite: ["prettier --write", "eslint --fix"],
+  },
+});
+```
+
+## Custom Scalar Types
+
+Map TypeScript types to GraphQL custom scalars via config. See [Scalars](./schema/scalars) for complete documentation including the `GqlScalar` approach.
+
+```ts
+export default defineConfig({
+  scalars: [
+    {
+      name: "DateTime",
+      tsType: { from: "./src/gqlkit/schema/scalars", name: "DateTime" },
+      description: "ISO 8601 datetime string",
+    },
+  ],
+});
+```
+
+## Output Paths
+
+Customize output file locations or disable specific outputs:
+
+```ts
+export default defineConfig({
+  output: {
+    typeDefsPath: "generated/schema.ts", // Custom path
+    resolversPath: "generated/resolvers.ts",
+    schemaPath: null, // Disable SDL output
+  },
+});
+```
+
+### Output Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `typeDefsPath` | `string` \| `null` | `"src/gqlkit/__generated__/typeDefs.ts"` | Path for the TypeDefs output |
+| `resolversPath` | `string` \| `null` | `"src/gqlkit/__generated__/resolvers.ts"` | Path for the resolvers output |
+| `schemaPath` | `string` \| `null` | `"src/gqlkit/__generated__/schema.graphql"` | Path for the SDL output |
+| `importExtension` | `"js"` \| `"none"` \| `"ts"` | `"js"` | File extension for import statements |
+
+Set any path to `null` to disable that output.
+
+The `importExtension` option controls file extensions in generated import statements:
+
+- `"js"` (default): Converts `.ts` to `.js` (compatible with ESM + Node16)
+- `"none"`: No extension (for bundlers like webpack, vite)
+- `"ts"`: Keeps `.ts` extension (for Deno)
+
+## Hooks
+
+Execute commands after file generation:
+
+```ts
+export default defineConfig({
+  hooks: {
+    // Single command
+    afterAllFileWrite: "prettier --write",
+  },
+});
+```
+
+You can also specify multiple commands to run sequentially:
+
+```ts
+export default defineConfig({
+  hooks: {
+    // Multiple commands (executed sequentially)
+    afterAllFileWrite: ["prettier --write", "eslint --fix"],
+  },
+});
+```
+
+### Available Hooks
+
+| Hook | Description |
+|------|-------------|
+| `afterAllFileWrite` | Runs after all generated files are written. Receives the list of written file paths. |
+
+## Source Directory
+
+By default, gqlkit scans `src/gqlkit/schema` for types and resolvers.
+
+```ts
+export default defineConfig({
+  sourceDir: "src/graphql/schema", // Custom source directory
+});
+```
+
+All TypeScript files (`.ts`, `.cts`, `.mts`) under this directory are scanned.
+
+## Ignore Patterns
+
+Exclude files from scanning using glob patterns:
+
+```ts
+export default defineConfig({
+  sourceIgnoreGlobs: [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/testdata/**",
+  ],
+});
+```

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/getting-started.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/getting-started.md
@@ -1,0 +1,120 @@
+---
+title: Getting Started
+description: Install gqlkit and create your first GraphQL schema from TypeScript.
+---
+
+# Getting Started
+
+## Installation
+
+```sh filename="npm"
+npm install @gqlkit-ts/runtime @graphql-tools/schema graphql
+npm install -D @gqlkit-ts/cli
+```
+
+```sh filename="pnpm"
+pnpm add @gqlkit-ts/runtime @graphql-tools/schema graphql
+pnpm add -D @gqlkit-ts/cli
+```
+
+```sh filename="yarn"
+yarn add @gqlkit-ts/runtime @graphql-tools/schema graphql
+yarn add -D @gqlkit-ts/cli
+```
+
+> [!TIP]
+>
+> If you use AI coding agents like Claude Code or Codex, run `gqlkit docs` to set up gqlkit skills. See [Coding Agents](./coding-agents) for details.
+
+## Project Structure
+
+gqlkit expects your types and resolvers to be in `src/gqlkit/schema/`:
+
+```
+src/
+└── gqlkit/
+    ├── context.ts       # Context type definition
+    ├── gqlkit.ts        # Resolver factories
+    └── schema/
+        ├── user.ts      # User type and resolvers
+        ├── post.ts      # Post type and resolvers
+        └── query.ts     # Query resolvers
+```
+
+## Set Up Context and Resolver Factories
+
+Create `src/gqlkit/context.ts` to define your context type:
+
+```typescript
+export type Context = {
+  currentUser: { id: string; name: string; email: string | null } | null;
+};
+```
+
+Create `src/gqlkit/gqlkit.ts` to export resolver factories:
+
+```typescript
+import { createGqlkitApis } from "@gqlkit-ts/runtime";
+import type { Context } from "./context";
+
+export const { defineQuery, defineMutation, defineField } =
+  createGqlkitApis<Context>();
+```
+
+## Define Your First Type and Query
+
+Create a simple User type and query in `src/gqlkit/schema/user.ts`:
+
+```typescript
+import { defineQuery } from "../gqlkit";
+import type { NoArgs } from "@gqlkit-ts/runtime";
+
+export type User = {
+  id: string;
+  name: string;
+  email: string | null;
+};
+
+// NoArgs indicates this query takes no arguments
+export const me = defineQuery<NoArgs, User | null>(
+  (_root, _args, ctx) => ctx.currentUser
+);
+```
+
+## Generate Schema
+
+Run the generator:
+
+```sh filename="npm"
+npm exec gqlkit gen
+```
+
+```sh filename="pnpm"
+pnpm gqlkit gen
+```
+
+```sh filename="yarn"
+yarn gqlkit gen
+```
+
+This will create files in `src/gqlkit/__generated__/`:
+- `schema.ts` - GraphQL schema AST (DocumentNode)
+- `resolvers.ts` - Resolver map
+
+## Create GraphQL Schema
+
+Use `@graphql-tools/schema` to combine the generated outputs into an executable schema:
+
+```typescript
+import { makeExecutableSchema } from "@graphql-tools/schema";
+import { typeDefs } from "./gqlkit/__generated__/schema";
+import { resolvers } from "./gqlkit/__generated__/resolvers";
+
+export const schema = makeExecutableSchema({ typeDefs, resolvers });
+```
+
+## Next Steps
+
+- [HTTP Server Integration](./integration/yoga) - Connect your schema to graphql-yoga, Apollo Server, or other HTTP servers
+- [Object Types](./schema/objects) - Learn more about defining types
+- [Queries & Mutations](./schema/queries-mutations) - Advanced resolver patterns

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/index.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/index.md
@@ -1,0 +1,47 @@
+# gqlkit
+
+gqlkit generates GraphQL schema and resolver maps from TypeScript types and functions.
+
+## How it works
+
+1. Write TypeScript types in `src/gqlkit/schema/` → become GraphQL types
+2. Write resolver functions using `defineQuery`, `defineMutation`, `defineField` → become GraphQL resolvers
+3. Run `gqlkit gen` → outputs `typeDefs` and `resolvers` to `src/gqlkit/__generated__/`
+
+## Design principles
+
+- **Implement first**: Write types and resolvers, generate schema when ready. No edit-regenerate-implement loops.
+- **Just types and functions**: Plain TypeScript with a thin API. No decorators, no complex generics.
+- **Type-safe**: TypeScript types become GraphQL types. Resolver signatures checked at compile time.
+
+## Documentation
+
+- [What is gqlkit?](./what-is-gqlkit.md): Just types and functions — write TypeScript, generate GraphQL.
+- [Getting Started](./getting-started.md): Install gqlkit and create your first GraphQL schema from TypeScript.
+
+## Schema Definition
+
+- [Schema Definition](./schema/conventions.md): gqlkit generates GraphQL schema from your TypeScript types.
+- [Defining Object Types](./schema/objects.md): Plain TypeScript type exports become GraphQL Object types.
+- [Defining Input Types](./schema/inputs.md): TypeScript types with Input suffix are treated as GraphQL input types.
+- [Defining Queries and Mutations](./schema/queries-mutations.md): Define Query and Mutation fields using the @gqlkit-ts/runtime API.
+- [Defining Field Resolvers](./schema/fields.md): Add computed fields to object types using defineField.
+- [Defining Scalar Types](./schema/scalars.md): gqlkit provides built-in scalar types and supports custom scalar definitions.
+- [Defining Enum Types](./schema/enums.md): gqlkit converts TypeScript string literal unions and enums to GraphQL enum types.
+- [Defining Union Types](./schema/unions.md): TypeScript union types of object types are converted to GraphQL union types.
+- [Defining Interface Types](./schema/interfaces.md): Define GraphQL interface types using the GqlInterface utility type.
+- [Resolving Abstract Types](./schema/abstract-resolvers.md): Handle runtime type resolution for GraphQL unions and interfaces.
+- [Adding Documentation to Schema](./schema/documentation.md): gqlkit extracts TSDoc/JSDoc comments and converts them to GraphQL descriptions.
+- [Defining Custom Directives](./schema/directives.md): Define custom directives using the GqlDirective utility type.
+
+## Integration
+
+- [Integration with graphql-yoga](./integration/yoga.md): Use gqlkit with graphql-yoga, a batteries-included GraphQL server.
+- [Integration with Apollo Server](./integration/apollo.md): Use gqlkit with Apollo Server, a popular GraphQL server.
+- [Integration with Drizzle ORM](./integration/drizzle.md): Derive GraphQL types from Drizzle table definitions.
+- [Integration with Prisma](./integration/prisma.md): Derive GraphQL types from Prisma model types.
+
+## Guides
+
+- [Configuration](./configuration.md): Configure gqlkit via gqlkit.config.ts in your project root.
+- [Coding Agents](./coding-agents.md): Set up AI coding agents like Claude Code and Codex to understand gqlkit conventions. (skip if reading via `gqlkit-guide` skill)

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/integration/apollo.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/integration/apollo.md
@@ -1,0 +1,77 @@
+---
+title: Integration with Apollo Server
+description: Use gqlkit with Apollo Server, a popular GraphQL server.
+---
+
+# Apollo Server
+
+[Apollo Server](https://www.apollographql.com/docs/apollo-server/) is a popular GraphQL server with extensive features and ecosystem.
+
+## Installation
+
+```sh filename="npm"
+npm install @apollo/server
+```
+
+```sh filename="pnpm"
+pnpm add @apollo/server
+```
+
+```sh filename="yarn"
+yarn add @apollo/server
+```
+
+## Prerequisites
+
+Create an executable schema following the [Getting Started guide](../getting-started.md#create-graphql-schema).
+
+## Basic Server
+
+Using the standalone server:
+
+```typescript
+// src/server.ts
+import { ApolloServer } from "@apollo/server";
+import { startStandaloneServer } from "@apollo/server/standalone";
+import { schema } from "./schema";
+
+const server = new ApolloServer({ schema });
+
+const { url } = await startStandaloneServer(server, {
+  listen: { port: 4000 },
+});
+
+console.log(`Server is running on ${url}`);
+```
+
+## With Context
+
+If your resolvers use a context type, first [set up context and resolver factories](../getting-started.md#set-up-context-and-resolver-factories), then provide a context factory to your server:
+
+```typescript
+// src/server.ts
+import { ApolloServer } from "@apollo/server";
+import { startStandaloneServer } from "@apollo/server/standalone";
+import { schema } from "./schema";
+import type { Context } from "./gqlkit/context";
+
+const server = new ApolloServer<Context>({ schema });
+
+const { url } = await startStandaloneServer(server, {
+  listen: { port: 4000 },
+  context: async ({ req }) => {
+    const user = await getUserFromRequest(req);
+    return {
+      currentUser: user,
+      db: database,
+    };
+  },
+});
+
+console.log(`Server is running on ${url}`);
+```
+
+## Further Reading
+
+- [Apollo Server Documentation](https://www.apollographql.com/docs/apollo-server/)
+- [Apollo Server Plugins](https://www.apollographql.com/docs/apollo-server/builtin-plugins)

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/integration/drizzle.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/integration/drizzle.md
@@ -1,0 +1,187 @@
+---
+title: Integration with Drizzle ORM
+description: Derive GraphQL types from Drizzle table definitions.
+---
+
+# Drizzle ORM
+
+[Drizzle ORM](https://orm.drizzle.team/) is a TypeScript ORM with type-safe schema definitions. gqlkit integrates seamlessly with Drizzle by using `InferSelectModel` and `InferInsertModel` to derive GraphQL types from your table definitions.
+
+## Installation
+
+```sh filename="npm"
+npm install drizzle-orm postgres
+```
+
+```sh filename="pnpm"
+pnpm add drizzle-orm postgres
+```
+
+```sh filename="yarn"
+yarn add drizzle-orm postgres
+```
+
+## Defining Tables
+
+Define your database tables with Drizzle:
+
+```typescript
+// src/db/schema.ts
+import { pgEnum, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+
+export const userStatusEnum = pgEnum("user_status", [
+  "active",
+  "inactive",
+  "suspended",
+]);
+
+export const users = pgTable("users", {
+  id: uuid().primaryKey().defaultRandom(),
+  name: text().notNull(),
+  email: text().notNull().unique(),
+  status: userStatusEnum().notNull().default("active"),
+  createdAt: timestamp().notNull().defaultNow(),
+});
+
+export const posts = pgTable("posts", {
+  id: uuid().primaryKey().defaultRandom(),
+  title: text().notNull(),
+  content: text(),
+  priority: text({ enum: ["low", "medium", "high"] }).notNull().default("medium"),
+  authorId: uuid()
+    .notNull()
+    .references(() => users.id),
+  createdAt: timestamp().notNull().defaultNow(),
+});
+```
+
+Both `pgEnum()` and `text({ enum: [...] })` are supported for defining enum columns. gqlkit automatically generates corresponding GraphQL enum types from these definitions.
+
+## Defining Custom Scalars
+
+Define custom scalar types using `GqlScalar` for fields like timestamps:
+
+```typescript
+// src/gqlkit/schema/scalars.ts
+import type { GqlScalar } from "@gqlkit-ts/runtime";
+
+export type DateTime = GqlScalar<"DateTime", Date>;
+```
+
+## Exporting GraphQL Types
+
+Use Drizzle's type inference utilities to export GraphQL types from your table definitions:
+
+```typescript
+// src/gqlkit/schema/user.ts
+import type { InferSelectModel } from "drizzle-orm";
+import { users as usersTable } from "../../db/schema.js";
+
+// Export as GraphQL object type
+export type User = InferSelectModel<typeof usersTable>;
+```
+
+This generates the following GraphQL schema:
+
+```graphql
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+  SUSPENDED
+}
+
+type User {
+  id: String!
+  name: String!
+  email: String!
+  status: UserStatus!
+  createdAt: DateTime!
+}
+```
+
+## Defining Resolvers
+
+Define resolvers that use the derived types:
+
+```typescript
+// src/gqlkit/schema/user.ts
+import type { NoArgs } from "@gqlkit-ts/runtime";
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { eq } from "drizzle-orm";
+import { posts as postsTable, users as usersTable } from "../../db/schema.js";
+import { defineField, defineMutation, defineQuery } from "../gqlkit.js";
+import type { Post } from "./post.js";
+
+export type User = InferSelectModel<typeof usersTable>;
+
+export const allUsers = defineQuery<NoArgs, User[]>(
+  async (_root, _args, ctx) => {
+    return ctx.db.select().from(usersTable);
+  },
+);
+
+export const user = defineQuery<{ id: string }, User | null>(
+  async (_root, args, ctx) => {
+    const result = await ctx.db
+      .select()
+      .from(usersTable)
+      .where(eq(usersTable.id, args.id));
+    return result[0] ?? null;
+  },
+);
+
+export const createUser = defineMutation<
+  { input: Omit<InferInsertModel<typeof usersTable>, "id" | "createdAt"> },
+  User
+>(async (_root, args, ctx) => {
+  const result = await ctx.db.insert(usersTable).values(args.input).returning();
+  return result[0]!;
+});
+
+export const posts = defineField<User, NoArgs, Post[]>(
+  async (parent, _args, ctx) => {
+    return ctx.db
+      .select()
+      .from(postsTable)
+      .where(eq(postsTable.authorId, parent.id));
+  },
+);
+```
+
+## Context with Database
+
+Set up the context type to include your database instance. For basic setup, see [Set Up Context and Resolver Factories](../getting-started.md#set-up-context-and-resolver-factories).
+
+```typescript
+// src/db/db.ts
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import * as schema from "./schema.js";
+
+const client = postgres(process.env.DATABASE_URL!);
+export const db = drizzle(client, { schema, casing: "snake_case" });
+export type Database = typeof db;
+```
+
+```typescript
+// src/gqlkit/context.ts
+import type { Database } from "../db/db.js";
+
+export type Context = {
+  db: Database;
+};
+```
+
+## Complete Example
+
+See the [examples/with-drizzle](https://github.com/gqlkit/gqlkit/tree/main/examples/with-drizzle) directory for a complete working example with:
+
+- PostgreSQL tables with DateTime scalar
+- Enum types using both `pgEnum()` and `text({ enum: [...] })`
+- User and Post types with relationships
+- Query, Mutation, and Field resolvers
+
+## Further Reading
+
+- [Drizzle ORM Documentation](https://orm.drizzle.team/docs/overview)
+- [Drizzle with PostgreSQL](https://orm.drizzle.team/docs/get-started/postgresql-new)

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/integration/prisma.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/integration/prisma.md
@@ -1,0 +1,196 @@
+---
+title: Integration with Prisma
+description: Derive GraphQL types from Prisma model types.
+---
+
+# Prisma
+
+[Prisma](https://www.prisma.io/) is a next-generation ORM for Node.js and TypeScript. gqlkit integrates seamlessly with Prisma by using its generated model types to derive GraphQL types from your schema definitions.
+
+## Installation
+
+```sh filename="npm"
+npm install prisma @prisma/client
+```
+
+```sh filename="pnpm"
+pnpm add prisma @prisma/client
+```
+
+```sh filename="yarn"
+yarn add prisma @prisma/client
+```
+
+## Defining the Schema
+
+Define your database schema in `prisma/schema.prisma`:
+
+```prisma
+// prisma/schema.prisma
+generator client {
+  provider = "prisma-client"
+  output   = "../src/__generated__/prisma"
+}
+
+datasource db {
+  provider = "sqlite"
+}
+
+enum UserStatus {
+  active
+  inactive
+  suspended
+}
+
+model User {
+  id        String     @id @default(uuid())
+  name      String
+  email     String     @unique
+  status    UserStatus @default(active)
+  createdAt DateTime   @default(now()) @map("created_at")
+  posts     Post[]
+
+  @@map("users")
+}
+
+enum PostPriority {
+  low
+  medium
+  high
+}
+
+model Post {
+  id        String       @id @default(uuid())
+  title     String
+  content   String?
+  priority  PostPriority @default(medium)
+  authorId  String       @map("author_id")
+  createdAt DateTime     @default(now()) @map("created_at")
+  author    User         @relation(fields: [authorId], references: [id])
+
+  @@map("posts")
+}
+```
+
+Enum types defined in the Prisma schema are automatically converted to corresponding GraphQL enum types by gqlkit.
+
+## Defining Custom Scalars
+
+Define custom scalar types using `GqlScalar` for fields like timestamps:
+
+```typescript
+// src/gqlkit/schema/scalars.ts
+import type { GqlScalar } from "@gqlkit-ts/runtime";
+
+export type DateTime = GqlScalar<"DateTime", Date>;
+```
+
+## Exporting GraphQL Types
+
+Use Prisma's generated model types to export GraphQL types from your schema definitions:
+
+```typescript
+// src/gqlkit/schema/user.ts
+import type { Prisma } from "../../__generated__/prisma/client.js";
+
+// Export as GraphQL object type
+export type User = Prisma.UserModel;
+```
+
+This generates the following GraphQL schema:
+
+```graphql
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+  SUSPENDED
+}
+
+type User {
+  id: String!
+  name: String!
+  email: String!
+  status: UserStatus!
+  createdAt: DateTime!
+}
+```
+
+## Defining Resolvers
+
+Define resolvers that use the derived types:
+
+```typescript
+// src/gqlkit/schema/user.ts
+import type { NoArgs } from "@gqlkit-ts/runtime";
+import type { Prisma } from "../../__generated__/prisma/client.js";
+import { defineField, defineMutation, defineQuery } from "../gqlkit.js";
+import type { Post } from "./post.js";
+
+export type User = Prisma.UserModel;
+
+export const allUsers = defineQuery<NoArgs, User[]>(
+  async (_root, _args, ctx) => {
+    return ctx.db.user.findMany();
+  },
+);
+
+export const user = defineQuery<{ id: string }, User | null>(
+  async (_root, args, ctx) => {
+    return ctx.db.user.findUnique({
+      where: { id: args.id },
+    });
+  },
+);
+
+export const createUser = defineMutation<
+  { input: Omit<Prisma.UserCreateInput, "id" | "createdAt" | "posts"> },
+  User
+>(async (_root, args, ctx) => {
+  return ctx.db.user.create({
+    data: args.input,
+  });
+});
+
+export const posts = defineField<User, NoArgs, Post[]>(
+  async (parent, _args, ctx) => {
+    return ctx.db.post.findMany({
+      where: { authorId: parent.id },
+    });
+  },
+);
+```
+
+## Context with Database
+
+Set up the context type to include your Prisma client instance. For basic setup, see [Set Up Context and Resolver Factories](../getting-started.md#set-up-context-and-resolver-factories).
+
+```typescript
+// src/db/db.ts
+import { PrismaClient } from "../__generated__/prisma/client.js";
+
+export const prisma = new PrismaClient();
+export type PrismaDatabase = typeof prisma;
+```
+
+```typescript
+// src/gqlkit/context.ts
+import type { PrismaDatabase } from "../db/db.js";
+
+export type Context = {
+  db: PrismaDatabase;
+};
+```
+
+## Complete Example
+
+See the [examples/with-prisma](https://github.com/gqlkit/gqlkit/tree/main/examples/with-prisma) directory for a complete working example with:
+
+- SQLite database with DateTime scalar
+- Enum types (`UserStatus`, `PostPriority`)
+- User and Post types with relationships
+- Query, Mutation, and Field resolvers
+
+## Further Reading
+
+- [Prisma Documentation](https://www.prisma.io/docs)
+- [Prisma Client API Reference](https://www.prisma.io/docs/orm/reference/prisma-client-reference)

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/integration/yoga.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/integration/yoga.md
@@ -1,0 +1,76 @@
+---
+title: Integration with graphql-yoga
+description: Use gqlkit with graphql-yoga, a batteries-included GraphQL server.
+---
+
+# graphql-yoga
+
+[graphql-yoga](https://the-guild.dev/graphql/yoga-server) is a batteries-included GraphQL server that works in any JavaScript runtime.
+
+## Installation
+
+```sh filename="npm"
+npm install graphql-yoga
+```
+
+```sh filename="pnpm"
+pnpm add graphql-yoga
+```
+
+```sh filename="yarn"
+yarn add graphql-yoga
+```
+
+## Prerequisites
+
+Create an executable schema following the [Getting Started guide](../getting-started.md#create-graphql-schema).
+
+## Basic Server
+
+```typescript
+// src/server.ts
+import { createServer } from "node:http";
+import { createYoga } from "graphql-yoga";
+import { schema } from "./schema";
+
+const yoga = createYoga({ schema });
+const server = createServer(yoga);
+
+server.listen(4000, () => {
+  console.log("Server is running on http://localhost:4000/graphql");
+});
+```
+
+## With Context
+
+If your resolvers use a context type, first [set up context and resolver factories](../getting-started.md#set-up-context-and-resolver-factories), then provide a context factory to your server:
+
+```typescript
+// src/server.ts
+import { createServer } from "node:http";
+import { createYoga } from "graphql-yoga";
+import { schema } from "./schema";
+import type { Context } from "./gqlkit/context";
+
+const yoga = createYoga<{}, Context>({
+  schema,
+  context: async ({ request }) => {
+    const user = await getUserFromRequest(request);
+    return {
+      currentUser: user,
+      db: database,
+    };
+  },
+});
+
+const server = createServer(yoga);
+
+server.listen(4000, () => {
+  console.log("Server is running on http://localhost:4000/graphql");
+});
+```
+
+## Further Reading
+
+- [graphql-yoga Documentation](https://the-guild.dev/graphql/yoga-server/docs)
+- [Envelop Plugins](https://the-guild.dev/graphql/envelop/plugins)

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/abstract-resolvers.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/abstract-resolvers.md
@@ -1,0 +1,263 @@
+---
+title: Resolving Abstract Types
+description: Handle runtime type resolution for GraphQL unions and interfaces.
+---
+
+# Abstract Type Resolution
+
+GraphQL abstract types (unions and interfaces) require runtime type resolution to determine the concrete type of returned values. gqlkit provides `defineResolveType` and `defineIsTypeOf` to handle this.
+
+## Overview
+
+When a GraphQL query returns an abstract type, the server needs to determine which concrete type to use. There are two approaches:
+
+| Approach | Defined On | Returns | Use Case |
+|----------|------------|---------|----------|
+| `resolveType` | Abstract type (union/interface) | Type name string | Single resolver decides the type |
+| `isTypeOf` | Object type | Boolean | Each type checks if value matches |
+
+## Automatic resolveType Generation
+
+When Union or Interface member types have `__typename` or `$typeName` fields with string literal values, gqlkit automatically generates the `resolveType` function. No manual definition is needed.
+
+### Basic Example
+
+```typescript
+export interface User {
+  __typename: "User";
+  id: string;
+  name: string;
+}
+
+export interface Post {
+  __typename: "Post";
+  id: string;
+  title: string;
+}
+
+export type SearchResult = User | Post;
+// resolveType is automatically generated: (obj) => obj.__typename
+```
+
+### Using `$typeName`
+
+If you prefer not to use `__typename` (e.g., to avoid conflicts with GraphQL introspection), you can use `$typeName` instead:
+
+```typescript
+export interface User {
+  $typeName: "User";
+  id: string;
+  name: string;
+}
+
+export interface Post {
+  $typeName: "Post";
+  id: string;
+  title: string;
+}
+
+export type SearchResult = User | Post;
+// resolveType is automatically generated: (obj) => obj.$typeName
+```
+
+### Priority Rules
+
+When both `__typename` and `$typeName` are present, `__typename` takes priority:
+
+```typescript
+export interface User {
+  __typename: "User";  // This value is used
+  $typeName: "UserType";
+  id: string;
+}
+```
+
+### Mixed Patterns
+
+When some members use `__typename` and others use `$typeName`, gqlkit generates a fallback pattern:
+
+```typescript
+export interface User {
+  __typename: "User";
+  id: string;
+}
+
+export interface Post {
+  $typeName: "Post";
+  id: string;
+}
+
+export type SearchResult = User | Post;
+// resolveType: (obj) => obj.__typename ?? obj.$typeName
+```
+
+### Requirements
+
+For automatic generation, the typename field must be:
+
+- Named `__typename` or `$typeName`
+- A **non-optional** field
+- A **non-nullable** type
+- A **string literal** type (not `string`)
+
+```typescript
+// ✅ OK: Valid typename fields
+interface Valid {
+  __typename: "TypeA";       // string literal, required
+}
+
+// ❌ Error: These will not trigger auto-generation
+interface Invalid1 {
+  __typename?: "TypeA";      // optional field
+}
+
+interface Invalid2 {
+  __typename: "TypeA" | null; // nullable type
+}
+
+interface Invalid3 {
+  __typename: string;        // not a string literal
+}
+```
+
+### When to Use Manual defineResolveType
+
+Use `defineResolveType` manually when:
+
+- Your types don't have `__typename` or `$typeName` fields
+- You need custom resolution logic (e.g., checking other properties)
+- You want to override the automatic generation
+
+## Using resolveType
+
+Define a `resolveType` resolver on a union or interface type to determine the concrete type.
+
+### Union Example
+
+```typescript
+import { defineResolveType } from "../gqlkit";
+
+export interface User {
+  id: string;
+  name: string;
+}
+
+export interface Post {
+  id: string;
+  title: string;
+}
+
+export type SearchResult = User | Post;
+
+export const searchResultResolveType = defineResolveType<SearchResult>(
+  (value) => {
+    if ("name" in value) {
+      return "User";
+    }
+    return "Post";
+  }
+);
+```
+
+### Interface Example
+
+```typescript
+import { defineResolveType } from "../gqlkit";
+import { type GqlInterface, type IDString } from "@gqlkit-ts/runtime";
+
+export type Node = GqlInterface<{
+  id: IDString;
+}>;
+
+export const nodeResolveType = defineResolveType<Node>((value) => {
+  if ("name" in value) {
+    return "User";
+  }
+  if ("title" in value) {
+    return "Post";
+  }
+  throw new Error("Unknown Node type");
+});
+```
+
+### Resolver Function Signature
+
+```typescript
+(value: TAbstract, context: TContext, info: GraphQLResolveInfo) => string | Promise<string>
+```
+
+| Argument | Description |
+|----------|-------------|
+| `value` | The resolved value to determine the type of |
+| `context` | The context object |
+| `info` | GraphQL resolve info |
+
+### Type Parameters
+
+`defineResolveType<TAbstract>`:
+
+| Parameter | Description |
+|-----------|-------------|
+| `TAbstract` | The abstract type (union or interface) to resolve |
+
+## Using isTypeOf
+
+Define an `isTypeOf` resolver on an object type to check if a value is of that type.
+
+### Basic Usage
+
+```typescript
+import { defineIsTypeOf } from "../gqlkit";
+
+export interface Dog {
+  kind: string;
+  name: string;
+  breed: string;
+}
+
+export interface Cat {
+  kind: string;
+  name: string;
+  indoor: boolean;
+}
+
+export type Animal = Dog | Cat;
+
+export const dogIsTypeOf = defineIsTypeOf<Dog>((value) => {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "kind" in value &&
+    value.kind === "dog"
+  );
+});
+
+export const catIsTypeOf = defineIsTypeOf<Cat>((value) => {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "kind" in value &&
+    value.kind === "cat"
+  );
+});
+```
+
+### Resolver Function Signature
+
+```typescript
+(value: unknown, context: TContext, info: GraphQLResolveInfo) => boolean | Promise<boolean>
+```
+
+| Argument | Description |
+|----------|-------------|
+| `value` | The value to check (typed as `unknown`) |
+| `context` | The context object |
+| `info` | GraphQL resolve info |
+
+### Type Parameters
+
+`defineIsTypeOf<TObject>`:
+
+| Parameter | Description |
+|-----------|-------------|
+| `TObject` | The object type to check against |

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/conventions.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/conventions.md
@@ -1,0 +1,59 @@
+---
+title: Schema Definition
+description: gqlkit generates GraphQL schema from your TypeScript types.
+---
+
+# Schema Definition
+
+gqlkit generates GraphQL schema from your TypeScript types. All exported types from `src/gqlkit/schema/` are automatically scanned and converted to GraphQL types.
+
+## Type Mapping
+
+gqlkit maps TypeScript types to GraphQL types as follows:
+
+| TypeScript | GraphQL |
+|------------|---------|
+| `string` | `String!` |
+| `number` | `Float!` |
+| `boolean` | `Boolean!` |
+| `IDString`, `IDNumber` | `ID!` |
+| `Int` (branded) | `Int!` |
+| `Float` (branded) | `Float!` |
+| `T \| null` | `T` (nullable) |
+| `T[]` | `[T!]!` |
+| String literal union | Enum type |
+| TypeScript `enum` | Enum type |
+| Union of object types | Union type |
+| `*Input` suffix types | Input Object type |
+| Union with `*Input` suffix | `@oneOf` input object |
+| `GqlInterface<T>` | Interface type |
+| `GqlScalar<Name, Base>` | Custom scalar |
+| `NoArgs` | Indicates resolver takes no arguments |
+
+## Naming Conventions
+
+gqlkit generates type names using predictable conventions:
+
+| Context | Pattern | Example |
+|---------|---------|---------|
+| Object field (inline) | `{ParentType}{Field}` | `User.profile` → `UserProfile` |
+| Input field (inline) | `{ParentWithoutInput}{Field}Input` | `CreateUserInput.address` → `CreateUserAddressInput` |
+| Query/Mutation arg | `{Resolver}{Arg}Input` | `searchUsers(filter)` → `SearchUsersFilterInput` |
+| Field resolver arg | `{Parent}{Field}{Arg}Input` | `User.posts(filter)` → `UserPostsFilterInput` |
+| Inline enum | Same as parent context | `User.status` → `UserStatus` |
+| Payload type | `{Resolver}Payload` | `updateUser` → `UpdateUserPayload` |
+
+For complete details on inline enum naming, see [Inline Enums](./enums.md#inline-enums).
+
+## Project Layout
+
+Default project layout:
+
+```
+src/
+  gqlkit/
+    schema/        # Types and resolvers co-located
+    __generated__/ # Generated files (auto-created)
+```
+
+All TypeScript files (`.ts`, `.cts`, `.mts`) under `src/gqlkit/schema/` are scanned for types and resolvers.

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/directives.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/directives.md
@@ -1,0 +1,201 @@
+---
+title: Defining Custom Directives
+description: Define custom directives using the GqlDirective utility type.
+---
+
+# Custom Directives
+
+Define custom directives using the `GqlDirective` utility type and attach them using `GqlField` or `GqlObject`.
+
+## Defining Directives
+
+```typescript
+// src/gqlkit/schema/directives.ts
+import { type GqlDirective } from "@gqlkit-ts/runtime";
+
+export type Role = "USER" | "ADMIN";
+
+// Directive with typed arguments
+export type AuthDirective<TArgs extends { role: Role[] }> = GqlDirective<
+  "auth",
+  TArgs,
+  "FIELD_DEFINITION"
+>;
+
+// Directive with multiple locations
+export type CacheDirective<TArgs extends { maxAge: number }> = GqlDirective<
+  "cache",
+  TArgs,
+  ["FIELD_DEFINITION", "OBJECT"]
+>;
+```
+
+Generates:
+
+```graphql
+directive @auth(role: [Role!]!) on FIELD_DEFINITION
+directive @cache(maxAge: Float!) on FIELD_DEFINITION | OBJECT
+```
+
+## GqlDirective Type Parameters
+
+`GqlDirective<Name, Args, Location>`:
+
+| Parameter | Description |
+|-----------|-------------|
+| `Name` | The directive name (without `@`) |
+| `Args` | The directive arguments type |
+| `Location` | Where the directive can be used (single or array) |
+
+### Directive Locations
+
+Common directive locations:
+
+| Location | Description |
+|----------|-------------|
+| `FIELD_DEFINITION` | Object type fields |
+| `OBJECT` | Object types |
+| `INPUT_FIELD_DEFINITION` | Input type fields |
+| `ARGUMENT_DEFINITION` | Field arguments |
+| `ENUM_VALUE` | Enum values |
+| `INTERFACE` | Interface types |
+
+## Attaching Directives to Fields
+
+Use `GqlField` to attach directives to object type fields:
+
+```typescript
+import { type GqlField, type IDString } from "@gqlkit-ts/runtime";
+import { type AuthDirective } from "./directives.js";
+
+export type User = {
+  id: IDString;
+  name: string;
+  // Field with directive
+  email: GqlField<string, { directives: [AuthDirective<{ role: ["ADMIN"] }>] }>;
+  // Nullable field with directive
+  phone: GqlField<string | null, { directives: [AuthDirective<{ role: ["USER"] }>] }>;
+};
+```
+
+Generates:
+
+```graphql
+type User {
+  id: ID!
+  name: String!
+  email: String! @auth(role: [ADMIN])
+  phone: String @auth(role: [USER])
+}
+```
+
+## Attaching Directives to Types
+
+Use `GqlObject` to attach directives to type definitions:
+
+```typescript
+import { type GqlObject, type IDString } from "@gqlkit-ts/runtime";
+import { type CacheDirective } from "./directives.js";
+
+export type Post = GqlObject<
+  {
+    id: IDString;
+    title: string;
+  },
+  { directives: [CacheDirective<{ maxAge: 60 }>] }
+>;
+```
+
+Generates:
+
+```graphql
+type Post @cache(maxAge: 60) {
+  id: ID!
+  title: String!
+}
+```
+
+## Attaching Directives to Query/Mutation Fields
+
+Add a third type parameter to `defineQuery`, `defineMutation`, or `defineField`:
+
+```typescript
+import { defineQuery } from "../gqlkit";
+import type { NoArgs } from "@gqlkit-ts/runtime";
+import { type AuthDirective } from "./directives.js";
+import type { User } from "./user.js";
+
+// Query field with directive
+export const me = defineQuery<
+  NoArgs,
+  User,
+  [AuthDirective<{ role: ["USER"] }>]
+>((_root, _args, ctx) => ctx.currentUser);
+```
+
+Generates:
+
+```graphql
+type Query {
+  me: User! @auth(role: [USER])
+}
+```
+
+## Attaching Directives to Field Resolvers
+
+```typescript
+import { defineField } from "../gqlkit";
+import type { NoArgs } from "@gqlkit-ts/runtime";
+import { type AuthDirective } from "./directives.js";
+
+export const email = defineField<
+  User,
+  NoArgs,
+  string,
+  [AuthDirective<{ role: ["ADMIN"] }>]
+>((parent) => parent.email);
+```
+
+## Multiple Directives
+
+Attach multiple directives by adding them to the array:
+
+```typescript
+export type Post = GqlObject<
+  {
+    id: IDString;
+    title: string;
+  },
+  {
+    directives: [
+      CacheDirective<{ maxAge: 60 }>,
+      AuthDirective<{ role: ["USER"] }>
+    ]
+  }
+>;
+```
+
+## Combining with Other Options
+
+Combine directives with `implements` and `defaultValue`:
+
+```typescript
+export type Post = GqlObject<
+  {
+    id: IDString;
+    title: string;
+    createdAt: DateTime;
+  },
+  {
+    implements: [Node, Timestamped],
+    directives: [CacheDirective<{ maxAge: 60 }>]
+  }
+>;
+
+export type CreatePostInput = {
+  title: GqlField<string, {
+    defaultValue: "Untitled";
+    directives: [LengthDirective<{ min: 1; max: 200 }>];
+  }>;
+};
+```

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/documentation.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/documentation.md
@@ -1,0 +1,181 @@
+---
+title: Adding Documentation to Schema
+description: gqlkit extracts TSDoc/JSDoc comments and converts them to GraphQL descriptions.
+---
+
+# Documentation
+
+gqlkit extracts TSDoc/JSDoc comments and converts them to GraphQL descriptions.
+
+## Type Descriptions
+
+Add descriptions to types using TSDoc/JSDoc comments:
+
+```typescript
+/**
+ * A user in the system
+ */
+export type User = {
+  /** Unique identifier */
+  id: IDString;
+  /** Display name */
+  name: string;
+};
+```
+
+Generates:
+
+```graphql
+"""
+A user in the system
+
+Defined in: src/gqlkit/schema/user.ts
+"""
+type User {
+  """Unique identifier"""
+  id: ID!
+  """Display name"""
+  name: String!
+}
+```
+
+## Field Descriptions
+
+Add descriptions to individual fields:
+
+```typescript
+export type User = {
+  /** Unique identifier for the user */
+  id: IDString;
+
+  /**
+   * The user's display name.
+   * This is shown in the UI and can be changed by the user.
+   */
+  name: string;
+
+  /** Email address (null if not verified) */
+  email: string | null;
+};
+```
+
+## Resolver Descriptions
+
+Add descriptions to Query, Mutation, and Field resolvers:
+
+```typescript
+/** Get the currently authenticated user */
+export const me = defineQuery<NoArgs, User | null>(
+  (_root, _args, ctx) => ctx.currentUser
+);
+
+/** Create a new user account */
+export const createUser = defineMutation<{ input: CreateUserInput }, User>(
+  (_root, args, ctx) => ctx.db.createUser(args.input)
+);
+
+/** Get user's profile URL */
+export const profileUrl = defineField<User, NoArgs, string>(
+  (parent) => `https://example.com/users/${parent.id}`
+);
+```
+
+## @deprecated Directive
+
+Mark fields and enum values as deprecated using the `@deprecated` JSDoc tag:
+
+### Deprecating Fields
+
+```typescript
+export type User = {
+  id: IDString;
+  name: string;
+  /**
+   * Legacy username
+   * @deprecated Use `name` field instead
+   */
+  username: string | null;
+};
+```
+
+Generates:
+
+```graphql
+type User {
+  id: ID!
+  name: String!
+  """Legacy username"""
+  username: String @deprecated(reason: "Use `name` field instead")
+}
+```
+
+### Deprecating Enum Values
+
+```typescript
+export enum UserStatus {
+  Active = "ACTIVE",
+  /**
+   * @deprecated Use `Inactive` instead
+   */
+  Pending = "PENDING",
+  Inactive = "INACTIVE",
+}
+```
+
+Generates:
+
+```graphql
+enum UserStatus {
+  ACTIVE
+  PENDING @deprecated(reason: "Use `Inactive` instead")
+  INACTIVE
+}
+```
+
+### Deprecating Resolvers
+
+```typescript
+/**
+ * Get user by username
+ * @deprecated Use `user(id: ID!)` instead
+ */
+export const userByUsername = defineQuery<{ username: string }, User | null>(
+  (_root, args, ctx) => ctx.db.findUserByUsername(args.username)
+);
+```
+
+## Multi-line Descriptions
+
+Multi-line comments are preserved:
+
+```typescript
+/**
+ * Represents a blog post.
+ *
+ * Posts can be in draft or published state.
+ * Only published posts are visible to other users.
+ */
+export type Post = {
+  id: IDString;
+  title: string;
+  content: string;
+};
+```
+
+Generates:
+
+```graphql
+"""
+Represents a blog post.
+
+Posts can be in draft or published state.
+Only published posts are visible to other users.
+
+Defined in: src/gqlkit/schema/post.ts
+"""
+type Post {
+  id: ID!
+  title: String!
+  content: String!
+}
+```

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/enums.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/enums.md
@@ -1,0 +1,469 @@
+---
+title: Defining Enum Types
+description: gqlkit converts TypeScript string literal unions and enums to GraphQL enum types.
+---
+
+# Enum Types
+
+gqlkit converts TypeScript string literal unions and enums to GraphQL enum types.
+
+## String Literal Unions
+
+String literal unions are automatically converted to GraphQL enum types:
+
+```typescript
+/**
+ * User account status
+ */
+export type UserStatus = "ACTIVE" | "INACTIVE" | "PENDING";
+```
+
+Generates:
+
+```graphql
+"""User account status"""
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+  PENDING
+}
+```
+
+## TypeScript Enums
+
+TypeScript string enums are also supported:
+
+```typescript
+export enum UserStatus {
+  Active = "ACTIVE",
+  Inactive = "INACTIVE",
+  Pending = "PENDING",
+}
+```
+
+Generates:
+
+```graphql
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+  PENDING
+}
+```
+
+## Deprecating Enum Values
+
+Use the `@deprecated` JSDoc tag to mark enum values as deprecated:
+
+```typescript
+export enum UserStatus {
+  Active = "ACTIVE",
+  /**
+   * @deprecated Use `Inactive` instead
+   */
+  Pending = "PENDING",
+  Inactive = "INACTIVE",
+}
+```
+
+For string literal unions, use a separate type with JSDoc:
+
+```typescript
+/**
+ * User account status
+ */
+export type UserStatus =
+  | "ACTIVE"
+  | /** @deprecated Use INACTIVE instead */ "PENDING"
+  | "INACTIVE";
+```
+
+Generates:
+
+```graphql
+enum UserStatus {
+  ACTIVE
+  PENDING @deprecated(reason: "Use INACTIVE instead")
+  INACTIVE
+}
+```
+
+## Using Enums in Types
+
+```typescript
+export type User = {
+  id: string;
+  name: string;
+  status: UserStatus;
+};
+
+export type UpdateUserInput = {
+  status: UserStatus | null;
+};
+```
+
+Generates:
+
+```graphql
+type User {
+  id: String!
+  name: String!
+  status: UserStatus!
+}
+
+input UpdateUserInput {
+  status: UserStatus
+}
+```
+
+## Inline Enums
+
+When you define a string literal union or reference a TypeScript enum **inline** (without exporting it from the schema directory), gqlkit automatically generates a GraphQL enum type. This follows the same pattern as [inline objects](./objects.md#inline-objects).
+
+### Inline String Literal Unions
+
+String literal unions used directly in field or argument types generate enum types automatically:
+
+```typescript
+export type User = {
+  id: string;
+  name: string;
+  /** Current account status */
+  status: "active" | "inactive" | "pendingReview";
+};
+```
+
+Generates:
+
+```graphql
+type User {
+  id: String!
+  name: String!
+  """Current account status"""
+  status: UserStatus!
+}
+
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+  PENDING_REVIEW
+}
+```
+
+The generated enum type name follows the convention `{ParentTypeName}{PascalCaseFieldName}`.
+
+### External TypeScript Enums
+
+TypeScript enums defined outside the schema directory are also automatically converted:
+
+```typescript
+// src/types/order.ts (outside schema directory)
+/**
+ * Order status in the system
+ */
+export enum OrderStatus {
+  /** Order is pending payment */
+  Pending = "pending",
+  /** Order is being processed */
+  Processing = "processing",
+  /** Order has been shipped */
+  Shipped = "shipped",
+}
+
+// src/gqlkit/schema/order.ts
+import { OrderStatus } from "../../types/order.js";
+
+export type Order = {
+  id: string;
+  status: OrderStatus;
+};
+```
+
+Generates:
+
+```graphql
+type Order {
+  id: String!
+  status: OrderStatus!
+}
+
+"""Order status in the system"""
+enum OrderStatus {
+  """Order is pending payment"""
+  PENDING
+  """Order is being processed"""
+  PROCESSING
+  """Order has been shipped"""
+  SHIPPED
+}
+```
+
+TSDoc comments on the enum and its values are preserved as GraphQL descriptions. The `@deprecated` tag is also supported.
+
+When the same external TypeScript enum is referenced in multiple places, gqlkit generates a single GraphQL enum type and reuses it across all references.
+
+### Inline Enum Naming Convention
+
+The naming convention for auto-generated enum types matches [inline objects](./objects.md#inline-objects):
+
+| Context | Naming Pattern | Example |
+|---------|----------------|---------|
+| Object field | `{ParentTypeName}{PascalCaseFieldName}` | `User.status` → `UserStatus` |
+| Input field | `{ParentTypeNameWithoutInputSuffix}{PascalCaseFieldName}Input` | `CreateUserInput.role` → `CreateUserRoleInput` |
+| Query/Mutation argument | `{PascalCaseFieldName}{PascalCaseArgName}Input` | `searchUsers(status: ...)` → `SearchUsersStatusInput` |
+| Field resolver argument | `{ParentTypeName}{PascalCaseFieldName}{PascalCaseArgName}Input` | `User.posts(filter: ...)` → `UserPostsFilterInput` |
+
+### Nullable Inline Enums
+
+Nullable inline enums are supported:
+
+```typescript
+export type User = {
+  id: string;
+  status: "active" | "inactive" | null;
+};
+```
+
+Generates:
+
+```graphql
+type User {
+  id: String!
+  status: UserStatus
+}
+
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+}
+```
+
+### Arrays of Inline Enums
+
+Inline enums in array types are also supported:
+
+```typescript
+export type User = {
+  id: string;
+  roles: ("admin" | "editor" | "viewer")[];
+};
+```
+
+Generates:
+
+```graphql
+type User {
+  id: String!
+  roles: [UserRoles!]!
+}
+
+enum UserRoles {
+  ADMIN
+  EDITOR
+  VIEWER
+}
+```
+
+### When Enums Are NOT Auto-Generated
+
+If you export a type from the schema directory, it is treated as an explicit type declaration and not auto-generated:
+
+```typescript
+// Exported from schema - used as-is, not auto-generated
+export type UserStatus = "active" | "inactive" | "pending";
+
+export type User = {
+  id: string;
+  status: UserStatus;  // References the exported type
+};
+```
+
+### Inline Enum Payloads
+
+String literal unions in resolver return types generate GraphQL Enum types with the naming convention `{ResolverName}Payload`:
+
+```typescript
+export const getStatus = defineQuery<NoArgs, "active" | "inactive" | "pending">(
+  (_root, _args, ctx) => ctx.db.getStatus()
+);
+```
+
+Generates:
+
+```graphql
+type Query {
+  getStatus: GetStatusPayload!
+}
+
+enum GetStatusPayload {
+  ACTIVE
+  INACTIVE
+  PENDING
+}
+```
+
+For field resolvers, the naming convention is `{ParentTypeName}{PascalCaseFieldName}Payload`:
+
+```typescript
+export const status = defineField<User, NoArgs, "online" | "offline" | "away">(
+  (parent) => parent.currentStatus
+);
+```
+
+Generates:
+
+```graphql
+type User {
+  status: UserStatusPayload!
+}
+
+enum UserStatusPayload {
+  ONLINE
+  OFFLINE
+  AWAY
+}
+```
+
+See [Queries & Mutations](./queries-mutations.md#inline-payload-types) for more details on inline payload types.
+
+## Automatic Case Conversion
+
+gqlkit automatically converts enum values to `SCREAMING_SNAKE_CASE` format, which is the GraphQL convention:
+
+```typescript
+export type UserStatus = "active" | "inProgress" | "pending_review" | "on-hold";
+```
+
+Generates:
+
+```graphql
+enum UserStatus {
+  ACTIVE
+  IN_PROGRESS
+  PENDING_REVIEW
+  ON_HOLD
+}
+```
+
+When conversion changes the original value, gqlkit generates resolver mappings to translate between GraphQL and TypeScript values:
+
+```typescript
+// Generated resolvers.ts
+export function createResolvers() {
+  return {
+    UserStatus: {
+      ACTIVE: "active",
+      IN_PROGRESS: "inProgress",
+      PENDING_REVIEW: "pending_review",
+      ON_HOLD: "on-hold",
+    },
+  };
+}
+```
+
+If values are already in `SCREAMING_SNAKE_CASE`, no resolver mapping is generated.
+
+### Automatic Prefix Stripping
+
+When all enum values share a common prefix that matches the enum name, gqlkit automatically strips the prefix to produce cleaner GraphQL values:
+
+```typescript
+export type UserStatus = "USER_STATUS_ACTIVE" | "USER_STATUS_INACTIVE" | "USER_STATUS_PENDING";
+```
+
+Generates:
+
+```graphql
+enum UserStatus {
+  ACTIVE
+  INACTIVE
+  PENDING
+}
+```
+
+This works with various naming conventions:
+
+| TypeScript Enum | Values | Generated GraphQL Values |
+|-----------------|--------|--------------------------|
+| `UserStatus` | `USER_STATUS_ACTIVE`, `USER_STATUS_INACTIVE` | `ACTIVE`, `INACTIVE` |
+| `orderStatus` | `ORDER_STATUS_PENDING`, `ORDER_STATUS_SHIPPED` | `PENDING`, `SHIPPED` |
+| `Status` | `STATUS_ACTIVE`, `STATUS_INACTIVE` | `ACTIVE`, `INACTIVE` |
+
+Prefix stripping is **not applied** when:
+
+- Not all values share the common prefix
+- Stripping would result in an empty value (e.g., `USER_STATUS_` for `UserStatus`)
+
+When prefix stripping is applied, gqlkit generates resolver mappings to preserve the original TypeScript values:
+
+```typescript
+// Generated resolvers.ts
+export function createResolvers() {
+  return {
+    UserStatus: {
+      ACTIVE: "USER_STATUS_ACTIVE",
+      INACTIVE: "USER_STATUS_INACTIVE",
+      PENDING: "USER_STATUS_PENDING",
+    },
+  };
+}
+```
+
+### Duplicate Value Detection
+
+If multiple TypeScript values convert to the same GraphQL enum value, gqlkit reports a `DUPLICATE_ENUM_VALUE_AFTER_CONVERSION` error:
+
+```typescript
+// Error: 'activeUser' and 'active_user' both convert to ACTIVE_USER
+export type Status = "activeUser" | "active_user" | "pending";
+```
+
+## Invalid Enum Values
+
+Enum values that are not valid GraphQL identifiers are automatically skipped with a warning. gqlkit converts enum values to `SCREAMING_SNAKE_CASE`, and the converted name must:
+
+- Match the pattern `/^[_A-Za-z][_0-9A-Za-z]*$/`
+- Not start with `__` (reserved for GraphQL introspection)
+
+### String Literal Unions
+
+```typescript
+export type Status =
+  | "active"      // ✅ Converts to ACTIVE
+  | "inProgress"  // ✅ Converts to IN_PROGRESS
+  | "0pending"    // ⚠️ Skipped: converts to 0PENDING (starts with number)
+  | "__internal"; // ⚠️ Skipped: converts to __INTERNAL (starts with __)
+```
+
+Generates:
+
+```graphql
+enum Status {
+  ACTIVE
+  IN_PROGRESS
+}
+```
+
+### TypeScript Enums
+
+```typescript
+export enum Priority {
+  HIGH = "HIGH",           // ✅ Valid
+  MEDIUM = "MEDIUM",       // ✅ Valid
+  LOW = "LOW",             // ✅ Valid
+  "0INVALID" = "0INVALID", // ⚠️ Skipped: starts with number
+  __RESERVED = "__RESERVED", // ⚠️ Skipped: starts with __
+}
+```
+
+Generates:
+
+```graphql
+enum Priority {
+  HIGH
+  MEDIUM
+  LOW
+}
+```
+
+When enum values are skipped, gqlkit outputs a warning with the original name, converted name, and location.

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/fields.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/fields.md
@@ -1,0 +1,250 @@
+---
+title: Defining Field Resolvers
+description: Add computed fields to object types using defineField.
+---
+
+# Field Resolvers
+
+Add computed fields to object types using `defineField`. Define them alongside the type.
+
+## Basic Usage
+
+```typescript
+// src/gqlkit/schema/user.ts
+import { defineField } from "../gqlkit";
+import type { IDString, NoArgs } from "@gqlkit-ts/runtime";
+import type { Post } from "./post.js";
+
+export type User = {
+  id: IDString;
+  name: string;
+};
+
+/** Get posts authored by this user */
+export const posts = defineField<User, NoArgs, Post[]>(
+  (parent) => findPostsByAuthor(parent.id)
+);
+
+/** Get user's post count */
+export const postCount = defineField<User, NoArgs, number>(
+  (parent) => countPostsByAuthor(parent.id)
+);
+```
+
+Generates:
+
+```graphql
+type User {
+  id: ID!
+  name: String!
+  """Get posts authored by this user"""
+  posts: [Post!]!
+  """Get user's post count"""
+  postCount: Float!
+}
+```
+
+## Resolver Function Signature
+
+Field resolvers receive four arguments:
+
+```typescript
+(parent, args, ctx, info) => ReturnType
+```
+
+| Argument | Description |
+|----------|-------------|
+| `parent` | The parent object (typed via the first type parameter) |
+| `args` | The arguments passed to the field |
+| `ctx` | The context object (typed via `gqlkit.ts`) |
+| `info` | GraphQL resolve info |
+
+## Type Parameters
+
+`defineField<TParent, TArgs, TResult>`:
+
+| Parameter | Description |
+|-----------|-------------|
+| `TParent` | The parent object type this field is defined on |
+| `TArgs` | The arguments type (use `NoArgs` if no arguments) |
+| `TResult` | The return type of the field |
+
+## Fields with Arguments
+
+```typescript
+export const posts = defineField<
+  User,
+  { limit: number; offset: number },
+  Post[]
+>((parent, args) => {
+  return findPostsByAuthor(parent.id, args.limit, args.offset);
+});
+```
+
+Generates:
+
+```graphql
+type User {
+  posts(limit: Float!, offset: Float!): [Post!]!
+}
+```
+
+## Inline Object Arguments
+
+Field resolver arguments can use inline object literals. gqlkit automatically generates Input Object types with the naming convention `{ParentTypeName}{PascalCaseFieldName}{PascalCaseArgName}Input`:
+
+```typescript
+import { defineField } from "../gqlkit";
+
+export const posts = defineField<
+  User,
+  {
+    /** Filter options */
+    filter: {
+      titlePattern: string | null;
+      status: PostStatus | null;
+    } | null;
+  },
+  Post[]
+>((parent, args) => []);
+```
+
+Generates:
+
+```graphql
+type User {
+  posts(
+    """Filter options"""
+    filter: UserPostsFilterInput
+  ): [Post!]!
+}
+
+input UserPostsFilterInput {
+  titlePattern: String
+  status: PostStatus
+}
+```
+
+Inline string literal unions and external TypeScript enums in arguments are also automatically converted to GraphQL enum types. See [Inline Enums](./enums.md#inline-enums) for details.
+
+## Inline Payload Types
+
+Field resolver return types can use inline object literals. gqlkit automatically generates GraphQL Object types with the naming convention `{ParentTypeName}{PascalCaseFieldName}Payload`:
+
+```typescript
+export const statistics = defineField<
+  User,
+  NoArgs,
+  { postCount: number; followerCount: number; isActive: boolean }
+>((parent, _args, ctx) => ctx.db.getUserStatistics(parent.id));
+```
+
+Generates:
+
+```graphql
+type User {
+  statistics: UserStatisticsPayload!
+}
+
+type UserStatisticsPayload {
+  postCount: Float!
+  followerCount: Float!
+  isActive: Boolean!
+}
+```
+
+### Inline Union Payloads
+
+Union types with inline object literals generate GraphQL Union types. Each union member must have a `__typename` property:
+
+```typescript
+export const verification = defineField<
+  User,
+  NoArgs,
+  | { __typename: "Verified"; verifiedAt: string }
+  | { __typename: "Unverified"; reason: string }
+>((parent) => parent.verification);
+```
+
+Generates:
+
+```graphql
+type User {
+  verification: UserVerificationPayload!
+}
+
+union UserVerificationPayload = Unverified | Verified
+
+type Verified {
+  verifiedAt: String!
+}
+
+type Unverified {
+  reason: String!
+}
+```
+
+See [Queries & Mutations](./queries-mutations.md#inline-payload-types) for more details on inline payload types.
+
+## Default Values in Arguments
+
+Default values in Input Objects are applied to resolver arguments:
+
+```typescript
+import { defineQuery } from "../gqlkit";
+import type { GqlField, Int } from "@gqlkit-ts/runtime";
+
+export type PaginationInput = {
+  limit: GqlField<Int, { defaultValue: 10 }>;
+  offset: GqlField<Int, { defaultValue: 0 }>;
+};
+
+export type User = {
+  id: string;
+  name: string;
+};
+
+export const users = defineQuery<PaginationInput, User[]>(() => []);
+```
+
+Generates:
+
+```graphql
+type Query {
+  users(limit: Int! = 10, offset: Int! = 0): [User!]!
+}
+```
+
+## Interface Field Resolvers
+
+Add computed fields to interface types using `defineField`:
+
+```typescript
+import { defineField } from "../gqlkit";
+import type { NoArgs } from "@gqlkit-ts/runtime";
+import type { Node } from "./node.js";
+
+/** Get the typename of a Node */
+export const __typename = defineField<Node, NoArgs, string>(
+  (parent) => parent.constructor.name
+);
+```
+
+## Attaching Directives
+
+Add a fourth type parameter to attach directives to field resolvers:
+
+```typescript
+import { defineField } from "../gqlkit";
+import type { NoArgs } from "@gqlkit-ts/runtime";
+import { type AuthDirective } from "./directives.js";
+
+export const email = defineField<
+  User,
+  NoArgs,
+  string,
+  [AuthDirective<{ role: ["ADMIN"] }>]
+>((parent) => parent.email);
+```
+
+See [Directives](./directives.md) for more details on defining and using custom directives.

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/inputs.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/inputs.md
@@ -1,0 +1,379 @@
+---
+title: Defining Input Types
+description: TypeScript types with Input suffix are treated as GraphQL input types.
+---
+
+# Input Types
+
+TypeScript types with `Input` suffix are treated as GraphQL input types.
+
+## Basic Usage
+
+```typescript
+/** Input for creating a new user */
+export interface CreateUserInput {
+  name: string;
+  email: string | null;
+}
+```
+
+Generates:
+
+```graphql
+"""Input for creating a new user"""
+input CreateUserInput {
+  name: String!
+  email: String
+}
+```
+
+## Inline Objects
+
+Input types can use inline object literals for nested structures. gqlkit automatically generates Input Object types with the naming convention `{ParentTypeNameWithoutInputSuffix}{PascalCaseFieldName}Input`:
+
+```typescript
+import type { GqlField, Int } from "@gqlkit-ts/runtime";
+
+export type CreateUserInput = {
+  name: string;
+  /** Profile information */
+  profile: {
+    bio: string | null;
+    /** User's age with default value */
+    age: GqlField<Int | null, { defaultValue: 18 }>;
+  };
+};
+```
+
+Generates:
+
+```graphql
+input CreateUserInput {
+  name: String!
+  """Profile information"""
+  profile: CreateUserProfileInput!
+}
+
+input CreateUserProfileInput {
+  """User's age with default value"""
+  age: Int = 18
+  bio: String
+}
+```
+
+Nested inline objects generate types with concatenated names (e.g., `UserProfileInput.address` → `UserProfileAddressInput`).
+
+Similarly, inline string literal unions and external TypeScript enums are automatically converted to GraphQL enum types. See [Inline Enums](./enums.md#inline-enums) for details.
+
+## @oneOf Input Objects
+
+Union types with `Input` suffix using inline object literals generate `@oneOf` input objects. Each union member must be an inline object literal with exactly one property. Property values can be scalar types, enum types, or references to Input Object types:
+
+```typescript
+/**
+ * Specifies how to identify a product.
+ * Exactly one field must be provided.
+ */
+export type ProductInput =
+  | { id: string }
+  | { name: string }
+  | { location: LocationInput };
+```
+
+Generates:
+
+```graphql
+"""
+Specifies how to identify a product.
+Exactly one field must be provided.
+"""
+input ProductInput @oneOf {
+  id: String
+  location: LocationInput
+  name: String
+}
+```
+
+Each property becomes a nullable field in the generated input type. The `@oneOf` directive ensures exactly one field is provided at runtime.
+
+### Inline @oneOf in Input Fields
+
+Union types can be used as field types within Input Objects to create nested `@oneOf` input objects. The generated type name follows the convention `{ParentTypeNameWithoutInputSuffix}{PascalCaseFieldName}Input`:
+
+```typescript
+export type CreateUserInput = {
+  name: string;
+  /**
+   * User identifier - either by ID or email
+   */
+  identifier: { id: string } | { email: string };
+};
+```
+
+Generates:
+
+```graphql
+input CreateUserInput {
+  name: String!
+  """User identifier - either by ID or email"""
+  identifier: CreateUserIdentifierInput!
+}
+
+input CreateUserIdentifierInput @oneOf {
+  email: String
+  id: String
+}
+```
+
+### Inline @oneOf in Resolver Arguments
+
+Inline unions in resolver arguments are also converted to `@oneOf` input objects:
+
+**Query/Mutation arguments** - naming convention: `{PascalCaseResolverName}{PascalCaseArgPath}Input`
+
+```typescript
+export const findUser = defineQuery<
+  {
+    criteria: {
+      identifier: { id: string } | { email: string };
+    };
+  },
+  User | null
+>(...);
+```
+
+Generates:
+
+```graphql
+input FindUserCriteriaIdentifierInput @oneOf {
+  email: String
+  id: String
+}
+
+input FindUserCriteriaInput {
+  identifier: FindUserCriteriaIdentifierInput!
+}
+
+type Query {
+  findUser(criteria: FindUserCriteriaInput!): User
+}
+```
+
+**Field resolver arguments** - naming convention: `{ParentTypeName}{PascalCaseFieldName}{PascalCaseArgPath}Input`
+
+```typescript
+export const posts = defineField<
+  User,
+  {
+    filter: { status: string } | { createdAfter: string } | null;
+  },
+  Post[]
+>(...);
+```
+
+Generates:
+
+```graphql
+input UserPostsFilterInput @oneOf {
+  createdAfter: String
+  status: String
+}
+
+type User {
+  posts(filter: UserPostsFilterInput): [Post!]!
+}
+```
+
+## Default Values
+
+Specify default values for Input Object fields using `GqlField` with the `defaultValue` option.
+
+### Basic Default Values
+
+```typescript
+import { type GqlField, type Int } from "@gqlkit-ts/runtime";
+
+export type PaginationInput = {
+  limit: GqlField<Int, { defaultValue: 10 }>;
+  offset: GqlField<Int, { defaultValue: 0 }>;
+  includeArchived: GqlField<boolean, { defaultValue: false }>;
+};
+
+export type SearchInput = {
+  query: string;
+  caseSensitive: GqlField<boolean, { defaultValue: true }>;
+  maxResults: GqlField<Int | null, { defaultValue: null }>;
+};
+
+export type GreetingInput = {
+  name: GqlField<string, { defaultValue: "World" }>;
+  prefix: GqlField<string, { defaultValue: "Hello" }>;
+};
+```
+
+Generates:
+
+```graphql
+input PaginationInput {
+  limit: Int! = 10
+  offset: Int! = 0
+  includeArchived: Boolean! = false
+}
+
+input SearchInput {
+  query: String!
+  caseSensitive: Boolean! = true
+  maxResults: Int = null
+}
+
+input GreetingInput {
+  name: String! = "World"
+  prefix: String! = "Hello"
+}
+```
+
+### Complex Default Values
+
+Default values support arrays, objects, and enum values:
+
+```typescript
+export type Status = "ACTIVE" | "INACTIVE" | "PENDING";
+
+export type Priority = "LOW" | "MEDIUM" | "HIGH";
+
+export type NestedConfig = {
+  enabled: boolean;
+  value: Int;
+};
+
+export type FilterInput = {
+  status: GqlField<Status, { defaultValue: "ACTIVE" }>;
+  priorities: GqlField<Priority[], { defaultValue: ["MEDIUM", "HIGH"] }>;
+  tags: GqlField<string[], { defaultValue: ["default"] }>;
+};
+
+export type SettingsInput = {
+  config: GqlField<NestedConfig, { defaultValue: { enabled: true; value: 100 } }>;
+  limits: GqlField<Int[], { defaultValue: [10, 20, 30] }>;
+};
+```
+
+Generates:
+
+```graphql
+input FilterInput {
+  status: Status! = ACTIVE
+  priorities: [Priority!]! = [MEDIUM, HIGH]
+  tags: [String!]! = ["default"]
+}
+
+input SettingsInput {
+  config: NestedConfig! = {enabled: true, value: 100}
+  limits: [Int!]! = [10, 20, 30]
+}
+```
+
+### Default Values with Directives
+
+You can combine `defaultValue` with `directives`:
+
+```typescript
+import { type GqlField, type GqlDirective, type Int } from "@gqlkit-ts/runtime";
+
+export type LengthDirective<TArgs extends { min: number; max: number }> =
+  GqlDirective<"length", TArgs, "INPUT_FIELD_DEFINITION" | "ARGUMENT_DEFINITION">;
+
+export type RangeDirective<TArgs extends { min: number; max: number }> =
+  GqlDirective<"range", TArgs, "INPUT_FIELD_DEFINITION" | "ARGUMENT_DEFINITION">;
+
+export type CreateUserInput = {
+  name: GqlField<string, {
+    defaultValue: "Anonymous";
+    directives: [LengthDirective<{ min: 1; max: 100 }>];
+  }>;
+  age: GqlField<Int, {
+    defaultValue: 18;
+    directives: [RangeDirective<{ min: 0; max: 150 }>];
+  }>;
+  email: GqlField<string | null, {
+    defaultValue: null;
+    directives: [LengthDirective<{ min: 5; max: 255 }>];
+  }>;
+};
+```
+
+Generates:
+
+```graphql
+input CreateUserInput {
+  name: String! = "Anonymous" @length(min: 1, max: 100)
+  age: Int! = 18 @range(min: 0, max: 150)
+  email: String = null @length(min: 5, max: 255)
+}
+```
+
+### Supported Default Value Types
+
+| Value type | Example | GraphQL output |
+|------------|---------|----------------|
+| String | `"hello"` | `"hello"` |
+| Number (Int) | `10` | `10` |
+| Number (Float) | `3.14` | `3.14` |
+| Boolean | `true`, `false` | `true`, `false` |
+| Null | `null` | `null` |
+| Array | `[1, 2, 3]` | `[1, 2, 3]` |
+| Object | `{ key: "value" }` | `{key: "value"}` |
+| Enum | `"ACTIVE"` (when field type is enum) | `ACTIVE` |
+
+### Literal Types Required
+
+Default values must be specified as TypeScript literal types. Non-literal types will cause a warning:
+
+```typescript
+// ✅ OK: Literal types
+export type GoodInput = {
+  limit: GqlField<Int, { defaultValue: 10 }>;
+  name: GqlField<string, { defaultValue: "default" }>;
+};
+
+// ❌ Error: Non-literal types
+export type BadInput = {
+  limit: GqlField<Int, { defaultValue: number }>;     // Warning: must be literal
+  name: GqlField<string, { defaultValue: string }>;   // Warning: must be literal
+};
+```
+
+## Excluding Fields
+
+Use `GqlObject` with the `ignoreFields` option to exclude specific fields from the generated Input Object. This is useful for internal fields that should not be accepted from clients:
+
+```typescript
+import { type GqlObject } from "@gqlkit-ts/runtime";
+
+/**
+ * Input for creating a user.
+ */
+export type CreateUserInput = GqlObject<
+  {
+    name: string;
+    email: string;
+    internalData: string;  // Internal field - excluded from schema
+    trackingId: string;    // Internal field - excluded from schema
+  },
+  { ignoreFields: "internalData" | "trackingId" }
+>;
+```
+
+Generates:
+
+```graphql
+"""Input for creating a user."""
+input CreateUserInput {
+  name: String!
+  email: String!
+}
+```
+
+## Invalid Field Names
+
+Input field names follow the same validation rules as object type fields. See [Invalid Field Names](./objects.md#invalid-field-names) for details.

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/interfaces.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/interfaces.md
@@ -1,0 +1,208 @@
+---
+title: Defining Interface Types
+description: Define GraphQL interface types using the GqlInterface utility type.
+---
+
+# Interface Types
+
+Define GraphQL interface types using the `GqlInterface` utility type.
+
+## Basic Usage
+
+```typescript
+// src/gqlkit/schema/node.ts
+import { type GqlInterface, type IDString } from "@gqlkit-ts/runtime";
+import type { DateTime } from "./scalars.js";
+
+/**
+ * Node interface - represents any entity with a unique identifier.
+ */
+export type Node = GqlInterface<{
+  /** Global unique identifier */
+  id: IDString;
+}>;
+
+/**
+ * Timestamped interface - entities that track creation time.
+ */
+export type Timestamped = GqlInterface<{
+  createdAt: DateTime;
+}>;
+```
+
+Generates:
+
+```graphql
+"""Node interface - represents any entity with a unique identifier."""
+interface Node {
+  """Global unique identifier"""
+  id: ID!
+}
+
+"""Timestamped interface - entities that track creation time."""
+interface Timestamped {
+  createdAt: DateTime!
+}
+```
+
+## GqlInterface Type Parameters
+
+`GqlInterface<T, Meta?>`:
+
+| Parameter | Description |
+|-----------|-------------|
+| `T` | The interface fields definition |
+| `Meta` | Optional: `{ implements: [...] }` for interface inheritance |
+
+## Interface Inheritance
+
+Interfaces can extend other interfaces:
+
+```typescript
+/**
+ * Entity interface - combines Node and Timestamped.
+ */
+export type Entity = GqlInterface<
+  {
+    id: IDString;
+    createdAt: DateTime;
+  },
+  { implements: [Node, Timestamped] }
+>;
+```
+
+Generates:
+
+```graphql
+"""Entity interface - combines Node and Timestamped."""
+interface Entity implements Node & Timestamped {
+  id: ID!
+  createdAt: DateTime!
+}
+```
+
+## Implementing Interfaces
+
+Use `GqlObject` with the `implements` option to declare that a type implements interfaces:
+
+```typescript
+import { type GqlObject, type IDString } from "@gqlkit-ts/runtime";
+import type { Node, Timestamped } from "./node.js";
+import type { DateTime } from "./scalars.js";
+
+/**
+ * A user in the system.
+ */
+export type User = GqlObject<
+  {
+    id: IDString;
+    name: string;
+    email: string | null;
+    createdAt: DateTime;
+  },
+  { implements: [Node, Timestamped] }
+>;
+```
+
+Generates:
+
+```graphql
+"""A user in the system."""
+type User implements Node & Timestamped {
+  id: ID!
+  name: String!
+  email: String
+  createdAt: DateTime!
+}
+```
+
+## Combining with Directives
+
+You can combine `implements` with `directives`:
+
+```typescript
+import { type GqlObject, type IDString } from "@gqlkit-ts/runtime";
+import type { Node, Timestamped } from "./node.js";
+import type { DateTime } from "./scalars.js";
+import type { CacheDirective } from "./directives.js";
+
+export type Post = GqlObject<
+  {
+    id: IDString;
+    title: string;
+    createdAt: DateTime;
+  },
+  {
+    implements: [Node, Timestamped],
+    directives: [CacheDirective<{ maxAge: 60 }>]
+  }
+>;
+```
+
+Generates:
+
+```graphql
+type Post @cache(maxAge: 60) implements Node & Timestamped {
+  id: ID!
+  title: String!
+  createdAt: DateTime!
+}
+```
+
+## Interface Field Resolvers
+
+Add computed fields to interface types using `defineField`:
+
+```typescript
+import { defineField } from "../gqlkit";
+import type { NoArgs } from "@gqlkit-ts/runtime";
+import type { Node } from "./node.js";
+
+/** Get the typename of a Node */
+export const __typename = defineField<Node, NoArgs, string>(
+  (parent) => parent.constructor.name
+);
+```
+
+See [Object Types](./objects.md) for more details on implementing interfaces.
+
+## Runtime Type Resolution
+
+When GraphQL executes a query that returns an interface type, it needs to determine the concrete type at runtime.
+
+### Automatic Resolution
+
+If all implementing types have `__typename` or `$typeName` fields with string literal values, gqlkit automatically generates the `resolveType` function:
+
+```typescript
+export interface User {
+  __typename: "User";
+  id: IDString;
+  name: string;
+}
+
+export interface Post {
+  __typename: "Post";
+  id: IDString;
+  title: string;
+}
+
+// Both User and Post implement Node
+// resolveType is automatically generated - no manual definition needed
+```
+
+### Manual Resolution
+
+For types without `__typename` or `$typeName`, use `defineResolveType` on the interface or `defineIsTypeOf` on each implementing type:
+
+```typescript
+import { defineResolveType } from "../gqlkit";
+
+export const nodeResolveType = defineResolveType<Node>((value) => {
+  if ("name" in value) return "User";
+  if ("title" in value) return "Post";
+  throw new Error("Unknown Node type");
+});
+```
+
+See [Abstract Type Resolution](./abstract-resolvers.md) for complete documentation.

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/objects.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/objects.md
@@ -1,0 +1,228 @@
+---
+title: Defining Object Types
+description: Plain TypeScript type exports become GraphQL Object types.
+---
+
+# Object Types
+
+Plain TypeScript type exports become GraphQL Object types.
+
+## Basic Usage
+
+Export a TypeScript type or interface:
+
+```typescript
+// src/gqlkit/schema/user.ts
+import { defineQuery, defineField } from "../gqlkit";
+import type { IDString, Int, NoArgs } from "@gqlkit-ts/runtime";
+
+/**
+ * A user in the system
+ */
+export type User = {
+  /** Unique identifier */
+  id: IDString;
+  /** Display name */
+  name: string;
+  /** Age in years */
+  age: Int;
+  /** Email address (null if not verified) */
+  email: string | null;
+};
+
+export const me = defineQuery<NoArgs, User | null>((_root, _args, ctx) => {
+  return findUserById(ctx.currentUserId);
+});
+
+/** Get user's profile URL */
+export const profileUrl = defineField<User, NoArgs, string>((parent) => {
+  return `https://example.com/users/${parent.id}`;
+});
+```
+
+## Nullability
+
+Use union with `null` to make fields nullable:
+
+```typescript
+export type User = {
+  email: string | null;  // nullable
+  name: string;          // non-null
+};
+```
+
+Generates:
+
+```graphql
+type User {
+  email: String
+  name: String!
+}
+```
+
+## Arrays
+
+Arrays are automatically converted to GraphQL lists:
+
+```typescript
+export type User = {
+  tags: string[];           // [String!]!
+  posts: Post[] | null;     // [Post!]
+};
+```
+
+## Inline Objects
+
+Object type fields can use inline object literals for nested structures. gqlkit automatically generates Object types with the naming convention `{ParentTypeName}{PascalCaseFieldName}`:
+
+```typescript
+export type User = {
+  id: string;
+  name: string;
+  /** User's profile information */
+  profile: {
+    /** User's biography */
+    bio: string;
+    age: number;
+  };
+};
+```
+
+Generates:
+
+```graphql
+type User {
+  id: String!
+  name: String!
+  """User's profile information"""
+  profile: UserProfile!
+}
+
+type UserProfile {
+  """User's biography"""
+  bio: String!
+  age: Float!
+}
+```
+
+Nested inline objects generate types with concatenated names (e.g., `User.profile.address` → `UserProfileAddress`).
+
+Similarly, inline string literal unions and external TypeScript enums are automatically converted to GraphQL enum types. See [Inline Enums](./enums.md#inline-enums) for details.
+
+## Implementing Interfaces
+
+Use `GqlObject` with the `implements` option to declare that a type implements interfaces:
+
+```typescript
+import { type GqlObject, type IDString } from "@gqlkit-ts/runtime";
+import type { Node, Timestamped } from "./node.js";
+import type { DateTime } from "./scalars.js";
+
+/**
+ * A user in the system.
+ */
+export type User = GqlObject<
+  {
+    id: IDString;
+    name: string;
+    email: string | null;
+    createdAt: DateTime;
+  },
+  { implements: [Node, Timestamped] }
+>;
+```
+
+Generates:
+
+```graphql
+"""A user in the system."""
+type User implements Node & Timestamped {
+  id: ID!
+  name: String!
+  email: String
+  createdAt: DateTime!
+}
+```
+
+You can combine `implements` with `directives`:
+
+```typescript
+export type Post = GqlObject<
+  {
+    id: IDString;
+    title: string;
+    createdAt: DateTime;
+  },
+  {
+    implements: [Node, Timestamped],
+    directives: [CacheDirective<{ maxAge: 60 }>]
+  }
+>;
+```
+
+See [Interfaces](./interfaces.md) for more details on defining interface types.
+
+## Excluding Fields
+
+Use `GqlObject` with the `ignoreFields` option to exclude specific fields from the generated GraphQL schema. This is useful for internal fields that should not be exposed in the public API:
+
+```typescript
+import { type GqlObject, type IDString } from "@gqlkit-ts/runtime";
+
+/**
+ * A user in the system.
+ */
+export type User = GqlObject<
+  {
+    id: IDString;
+    name: string;
+    email: string | null;
+    internalId: string;  // Internal field - excluded from schema
+    cacheKey: string;    // Internal field - excluded from schema
+  },
+  { ignoreFields: "internalId" | "cacheKey" }
+>;
+```
+
+Generates:
+
+```graphql
+"""A user in the system."""
+type User {
+  id: ID!
+  name: String!
+  email: String
+}
+```
+
+The excluded fields (`internalId` and `cacheKey`) are not included in the generated schema, and no resolvers are generated for them.
+
+## Invalid Field Names
+
+Field names that are not valid GraphQL identifiers are automatically skipped with a warning. Valid GraphQL names must:
+
+- Match the pattern `/^[_A-Za-z][_0-9A-Za-z]*$/`
+- Not start with `__` (reserved for GraphQL introspection)
+
+```typescript
+export type User = {
+  id: string;              // ✅ Valid
+  userName: string;        // ✅ Valid
+  _internal: string;       // ✅ Valid (single underscore is OK)
+  "0invalid": string;      // ⚠️ Skipped: starts with a number
+  __reserved: string;      // ⚠️ Skipped: starts with __
+  "field-name": string;    // ⚠️ Skipped: contains hyphen
+};
+```
+
+Generates (invalid fields are skipped):
+
+```graphql
+type User {
+  id: String!
+  userName: String!
+  _internal: String!
+}
+```
+
+When fields are skipped, gqlkit outputs a warning with the field name and location.

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/queries-mutations.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/queries-mutations.md
@@ -1,0 +1,321 @@
+---
+title: Defining Queries and Mutations
+description: Define Query and Mutation fields using the @gqlkit-ts/runtime API.
+---
+
+# Queries & Mutations
+
+Define Query and Mutation fields using the `@gqlkit-ts/runtime` API.
+
+> **Prerequisites**: This guide assumes you have completed the [basic setup](../getting-started.md#set-up-context-and-resolver-factories).
+
+## Query Resolvers
+
+Use `defineQuery` to define Query fields. The export name becomes the GraphQL field name:
+
+```typescript
+import { defineQuery } from "../gqlkit";
+import type { NoArgs } from "@gqlkit-ts/runtime";
+import type { User } from "./user";
+
+// Query.me
+export const me = defineQuery<NoArgs, User | null>(
+  (_root, _args, ctx) => {
+    return ctx.db.findUser(ctx.userId);
+  }
+);
+
+// Query.user(id: String!)
+export const user = defineQuery<{ id: string }, User | null>(
+  (_root, args, ctx) => {
+    return ctx.db.findUser(args.id);
+  }
+);
+
+// Query.users
+export const users = defineQuery<NoArgs, User[]>(
+  (_root, _args, ctx) => {
+    return ctx.db.findAllUsers();
+  }
+);
+```
+
+Generates:
+
+```graphql
+type Query {
+  me: User
+  user(id: String!): User
+  users: [User!]!
+}
+```
+
+## Mutation Resolvers
+
+Use `defineMutation` to define Mutation fields:
+
+```typescript
+import { defineMutation } from "../gqlkit";
+import type { User, CreateUserInput } from "./user";
+
+// Mutation.createUser(input: CreateUserInput!)
+export const createUser = defineMutation<{ input: CreateUserInput }, User>(
+  (_root, args, ctx) => {
+    return ctx.db.createUser(args.input);
+  }
+);
+
+// Mutation.deleteUser(id: String!)
+export const deleteUser = defineMutation<{ id: string }, boolean>(
+  (_root, args, ctx) => {
+    return ctx.db.deleteUser(args.id);
+  }
+);
+```
+
+Generates:
+
+```graphql
+type Mutation {
+  createUser(input: CreateUserInput!): User!
+  deleteUser(id: String!): Boolean!
+}
+```
+
+## Resolver Function Signature
+
+Query and Mutation resolvers receive four arguments:
+
+```typescript
+(root, args, ctx, info) => ReturnType
+```
+
+| Argument | Description |
+|----------|-------------|
+| `root` | The root value (usually undefined) |
+| `args` | The arguments passed to the field |
+| `ctx` | The context object (typed via `createGqlkitApis<Context>()`) |
+| `info` | GraphQL resolve info |
+
+## NoArgs Type
+
+Use the `NoArgs` type when a field has no arguments:
+
+```typescript
+import { type NoArgs } from "@gqlkit-ts/runtime";
+
+export const me = defineQuery<NoArgs, User | null>(
+  (_root, _args, ctx) => ctx.currentUser
+);
+```
+
+## Arguments with Input Types
+
+Use Input types for complex arguments:
+
+```typescript
+export type SearchUsersInput = {
+  query: string;
+  limit: number | null;
+};
+
+export const searchUsers = defineQuery<{ input: SearchUsersInput }, User[]>(
+  (_root, args) => {
+    return findUsers(args.input.query, args.input.limit ?? 10);
+  }
+);
+```
+
+## Inline Object Arguments
+
+Arguments can use inline object literals. gqlkit automatically generates Input Object types:
+
+```typescript
+export const searchUsers = defineQuery<
+  {
+    /** Search filter */
+    filter: {
+      namePattern: string | null;
+      status: UserStatus | null;
+    };
+  },
+  User[]
+>((_root, args) => []);
+```
+
+Generates:
+
+```graphql
+type Query {
+  searchUsers(
+    """Search filter"""
+    filter: SearchUsersFilterInput!
+  ): [User!]!
+}
+
+input SearchUsersFilterInput {
+  namePattern: String
+  status: UserStatus
+}
+```
+
+Inline string literal unions and external TypeScript enums in arguments are also automatically converted to GraphQL enum types. See [Inline Enums](./enums.md#inline-enums) for details.
+
+See [Field Resolvers](./fields.md) for more details on inline object arguments.
+
+## Inline Payload Types
+
+Return types can use inline object literals. gqlkit automatically generates GraphQL Object types with the naming convention `{PascalCaseResolverName}Payload`:
+
+```typescript
+export const updateUser = defineMutation<
+  { input: UpdateUserInput },
+  { user: User; updatedAt: string }
+>((_root, args, ctx) => ({
+  user: ctx.db.updateUser(args.input),
+  updatedAt: new Date().toISOString(),
+}));
+```
+
+Generates:
+
+```graphql
+type Mutation {
+  updateUser(input: UpdateUserInput!): UpdateUserPayload!
+}
+
+type UpdateUserPayload {
+  user: User!
+  updatedAt: String!
+}
+```
+
+### Inline Union Payloads
+
+Union types with inline object literals generate GraphQL Union types. Each union member must have a `__typename` property with a string literal type:
+
+```typescript
+export const updateUser = defineMutation<
+  { input: UpdateUserInput },
+  | { __typename: "UpdateUserSuccess"; user: User }
+  | { __typename: "UpdateUserError"; message: string }
+>((_root, args, ctx) => {
+  const result = ctx.db.updateUser(args.input);
+  if (result.ok) {
+    return { __typename: "UpdateUserSuccess", user: result.user };
+  }
+  return { __typename: "UpdateUserError", message: result.error };
+});
+```
+
+Generates:
+
+```graphql
+type Mutation {
+  updateUser(input: UpdateUserInput!): UpdateUserPayload!
+}
+
+union UpdateUserPayload = UpdateUserError | UpdateUserSuccess
+
+type UpdateUserSuccess {
+  user: User!
+}
+
+type UpdateUserError {
+  message: String!
+}
+```
+
+The `__resolveType` function is automatically generated based on the `__typename` property. See [Abstract Type Resolution](./abstract-resolvers.md) for more details.
+
+### Inline Enum Payloads
+
+String literal unions in return types generate GraphQL Enum types:
+
+```typescript
+export const getStatus = defineQuery<NoArgs, "active" | "inactive" | "pending">(
+  (_root, _args, ctx) => ctx.db.getStatus()
+);
+```
+
+Generates:
+
+```graphql
+type Query {
+  getStatus: GetStatusPayload!
+}
+
+enum GetStatusPayload {
+  ACTIVE
+  INACTIVE
+  PENDING
+}
+```
+
+### Nested Inline Types
+
+Inline types can be nested within payload objects:
+
+```typescript
+export const createOrder = defineMutation<
+  { input: CreateOrderInput },
+  {
+    order: {
+      id: string;
+      status: "pending" | "confirmed";
+      items: { productId: string; quantity: number }[];
+    };
+  }
+>(/* ... */);
+```
+
+Generates:
+
+```graphql
+type CreateOrderPayload {
+  order: CreateOrderPayloadOrder!
+}
+
+type CreateOrderPayloadOrder {
+  id: String!
+  status: CreateOrderPayloadOrderStatus!
+  items: [CreateOrderPayloadOrderItems!]!
+}
+
+enum CreateOrderPayloadOrderStatus {
+  PENDING
+  CONFIRMED
+}
+
+type CreateOrderPayloadOrderItems {
+  productId: String!
+  quantity: Float!
+}
+```
+
+## Attaching Directives
+
+Add a third type parameter to attach directives to Query/Mutation fields:
+
+```typescript
+import { defineQuery } from "../gqlkit";
+import type { NoArgs } from "@gqlkit-ts/runtime";
+import { type AuthDirective } from "./directives.js";
+import type { User } from "./user.js";
+
+export const me = defineQuery<
+  NoArgs,
+  User,
+  [AuthDirective<{ role: ["USER"] }>]
+>((_root, _args, ctx) => ctx.currentUser);
+```
+
+Generates:
+
+```graphql
+type Query {
+  me: User! @auth(role: [USER])
+}
+```
+
+See [Directives](./directives.md) for more details on defining and using custom directives.

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/scalars.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/scalars.md
@@ -1,0 +1,199 @@
+---
+title: Defining Scalar Types
+description: gqlkit provides built-in scalar types and supports custom scalar definitions.
+---
+
+# Scalar Types
+
+gqlkit provides built-in scalar types and supports custom scalar definitions.
+
+## Built-in Scalar Types
+
+gqlkit provides branded types to explicitly specify GraphQL scalar mappings:
+
+| TypeScript type | GraphQL type |
+|-----------------|--------------|
+| `IDString`      | `ID!`        |
+| `IDNumber`      | `ID!`        |
+| `Int`           | `Int!`       |
+| `Float`         | `Float!`     |
+| `string`        | `String!`    |
+| `number`        | `Float!`     |
+| `boolean`       | `Boolean!`   |
+
+### Usage
+
+```typescript
+import { type IDString, type Int, type Float } from "@gqlkit-ts/runtime";
+
+export type User = {
+  id: IDString;       // ID!
+  age: Int;           // Int!
+  score: Float;       // Float!
+  name: string;       // String!
+  balance: number;    // Float!
+  active: boolean;    // Boolean!
+};
+```
+
+## Custom Scalars with GqlScalar
+
+Define custom scalar types using the `GqlScalar` utility type:
+
+```typescript
+// src/gqlkit/schema/scalars.ts
+import { type GqlScalar } from "@gqlkit-ts/runtime";
+
+/**
+ * ISO 8601 format date-time string
+ */
+export type DateTime = GqlScalar<"DateTime", Date>;
+```
+
+Generates:
+
+```graphql
+"""ISO 8601 format date-time string"""
+scalar DateTime
+```
+
+### GqlScalar Type Parameters
+
+`GqlScalar<Name, Base, Only?>`:
+
+| Parameter | Description |
+|-----------|-------------|
+| `Name` | The GraphQL scalar name |
+| `Base` | The TypeScript type that backs this scalar |
+| `Only` | Optional: `"input"` or `"output"` to restrict usage |
+
+### Input-only and Output-only Scalars
+
+Restrict scalar usage to input or output positions:
+
+```typescript
+import { type GqlScalar } from "@gqlkit-ts/runtime";
+
+// Input-only scalar (for input positions only)
+export type DateTimeInput = GqlScalar<"DateTime", Date, "input">;
+
+// Output-only scalar (for output positions only)
+export type DateTimeOutput = GqlScalar<"DateTime", Date | string, "output">;
+```
+
+This is useful when input and output representations differ.
+
+## Config-based Custom Scalars
+
+Alternatively, map TypeScript types to GraphQL custom scalars via config:
+
+```typescript
+// gqlkit.config.ts
+import { defineConfig } from "@gqlkit-ts/cli";
+
+export default defineConfig({
+  scalars: [
+    {
+      name: "DateTime",
+      tsType: { from: "./src/gqlkit/schema/scalars", name: "DateTime" },
+      description: "ISO 8601 datetime string",
+    },
+    {
+      name: "UUID",
+      tsType: { name: "string" },  // Global type
+      only: "input",  // Input-only scalar
+    },
+  ],
+});
+```
+
+### Config Options
+
+| Option | Description |
+|--------|-------------|
+| `name` | The GraphQL scalar name |
+| `tsType.name` | The TypeScript type name |
+| `tsType.from` | Optional: import path for the type |
+| `description` | Optional: GraphQL description |
+| `only` | Optional: `"input"` or `"output"` |
+
+## Using Custom Scalars
+
+Once defined, use custom scalars in your types:
+
+```typescript
+import type { DateTime } from "./scalars.js";
+
+export type User = {
+  id: IDString;
+  name: string;
+  createdAt: DateTime;
+  updatedAt: DateTime | null;
+};
+
+export type CreateUserInput = {
+  name: string;
+  birthDate: DateTime;
+};
+```
+
+## Registering Scalar Resolvers
+
+Custom scalars require resolver implementations to handle serialization and parsing at runtime. Pass scalar resolvers to `createResolvers`:
+
+```typescript
+import { createResolvers } from "./gqlkit/__generated__/resolvers.js";
+
+const resolvers = createResolvers({
+  scalars: {
+    DateTime: myDateTimeScalar,
+  },
+});
+```
+
+### Using graphql-scalars (Recommended)
+
+The easiest way to implement custom scalars is to use [graphql-scalars](https://the-guild.dev/graphql/scalars), which provides ready-to-use implementations for common scalar types:
+
+```typescript
+import { GraphQLDateTime } from "graphql-scalars";
+
+const resolvers = createResolvers({
+  scalars: {
+    DateTime: GraphQLDateTime,
+  },
+});
+```
+
+This approach requires no manual serialize/parse implementation.
+
+### Custom Implementation
+
+For custom behavior, create your own `GraphQLScalarType`:
+
+```typescript
+import { GraphQLScalarType, Kind } from "graphql";
+
+const DateTimeScalar = new GraphQLScalarType({
+  name: "DateTime",
+  description: "ISO 8601 date-time string",
+  serialize(value) {
+    return value instanceof Date ? value.toISOString() : value;
+  },
+  parseValue(value) {
+    return new Date(value as string);
+  },
+  parseLiteral(ast) {
+    if (ast.kind === Kind.STRING) {
+      return new Date(ast.value);
+    }
+    return null;
+  },
+});
+
+const resolvers = createResolvers({
+  scalars: {
+    DateTime: DateTimeScalar,
+  },
+});
+```

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/unions.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/schema/unions.md
@@ -1,0 +1,297 @@
+---
+title: Defining Union Types
+description: TypeScript union types of object types are converted to GraphQL union types.
+---
+
+# Union Types
+
+TypeScript union types of object types are converted to GraphQL union types.
+
+## Basic Usage
+
+```typescript
+import type { Post } from "./Post";
+import type { Comment } from "./Comment";
+
+/**
+ * Content that can be searched
+ */
+export type SearchResult = Post | Comment;
+```
+
+Generates:
+
+```graphql
+"""Content that can be searched"""
+union SearchResult = Comment | Post
+```
+
+## Using Unions in Resolvers
+
+```typescript
+import { defineQuery } from "../gqlkit";
+import type { SearchResult } from "./types";
+
+export const search = defineQuery<{ query: string }, SearchResult[]>(
+  (_root, args, ctx) => {
+    return ctx.db.search(args.query);
+  }
+);
+```
+
+Generates:
+
+```graphql
+type Query {
+  search(query: String!): [SearchResult!]!
+}
+```
+
+## Inline Unions
+
+When a field type is an inline union of object types, gqlkit automatically generates a GraphQL Union type. The generated type name follows the convention `{ParentTypeName}{PascalCaseFieldName}`:
+
+```typescript
+import type { User } from "./User";
+import type { Post } from "./Post";
+
+export type SearchResult = {
+  id: string;
+  /**
+   * The matched item - either a User or a Post
+   */
+  item: User | Post;
+};
+```
+
+Generates:
+
+```graphql
+type SearchResult {
+  id: String!
+  """The matched item - either a User or a Post"""
+  item: SearchResultItem!
+}
+
+union SearchResultItem = Post | User
+```
+
+### Nullable Inline Unions
+
+Inline unions can be nullable:
+
+```typescript
+export type Container = {
+  id: string;
+  result: User | Post | null;
+};
+```
+
+Generates:
+
+```graphql
+type Container {
+  id: String!
+  result: ContainerResult
+}
+
+union ContainerResult = Post | User
+```
+
+### Known Type References
+
+When union members are exported types in the schema directory (`knownTypeNames`), they are preserved as references. Unknown inline object types are automatically generated:
+
+```typescript
+import type { User } from "./User"; // known type
+
+export type Activity = {
+  actor: User | { id: string; type: string }; // User is referenced, anonymous object is generated
+};
+```
+
+Generates:
+
+```graphql
+type Activity {
+  actor: ActivityActor!
+}
+
+union ActivityActor = ActivityActorAnonymous | User
+
+type ActivityActorAnonymous {
+  id: String!
+  type: String!
+}
+```
+
+### Validation
+
+Inline unions in output context must contain only object types. The following are not allowed:
+
+- Primitive types (string, number, boolean)
+- Enum types
+- Scalar types
+
+```typescript
+// These will produce errors:
+export type Invalid = {
+  value: string | number;        // Error: primitives not allowed
+  status: User | "active";       // Error: cannot mix object and enum
+};
+```
+
+## Union vs Enum
+
+- Use **Union** when each member is a distinct object type with different fields
+- Use **Enum** when you need a set of string constants
+
+```typescript
+// Union: Different object types
+export type SearchResult = Post | Comment | User;
+
+// Enum: String constants
+export type Status = "ACTIVE" | "INACTIVE" | "PENDING";
+```
+
+## Union vs Interface
+
+- Use **Union** when types share no common fields
+- Use **Interface** when types share common fields that should be queryable
+
+```typescript
+// Union: No common structure required
+export type SearchResult = Post | Comment;
+
+// Interface: Common fields enforced
+export type Node = GqlInterface<{
+  id: IDString;
+}>;
+```
+
+See [Interfaces](./interfaces.md) for more details on interface types.
+
+## Inline Union Payloads
+
+When a resolver return type is an inline union with object literals, gqlkit generates a GraphQL Union type. Each union member must have a `__typename` property with a string literal type:
+
+```typescript
+export const updateUser = defineMutation<
+  { input: UpdateUserInput },
+  | { __typename: "UpdateUserSuccess"; user: User }
+  | { __typename: "UpdateUserError"; message: string }
+>(/* ... */);
+```
+
+Generates:
+
+```graphql
+type Mutation {
+  updateUser(input: UpdateUserInput!): UpdateUserPayload!
+}
+
+union UpdateUserPayload = UpdateUserError | UpdateUserSuccess
+
+type UpdateUserSuccess {
+  user: User!
+}
+
+type UpdateUserError {
+  message: String!
+}
+```
+
+### `__typename` Requirement
+
+For inline union payloads, the `__typename` property is required and must be a string literal type:
+
+```typescript
+// ✅ OK: __typename with string literal type
+type Result =
+  | { __typename: "Success"; data: string }
+  | { __typename: "Error"; message: string };
+
+// ❌ Error: __typename missing
+type Invalid =
+  | { data: string }
+  | { message: string };
+
+// ❌ Error: __typename is not a string literal
+type AlsoInvalid =
+  | { __typename: string; data: string }
+  | { __typename: string; message: string };
+```
+
+### Automatic `__resolveType` Generation
+
+For inline union payloads, gqlkit automatically generates a `__resolveType` function that returns the `__typename` property value. You don't need to define it manually.
+
+If you need custom type resolution logic, use [defineResolveType](./abstract-resolvers.md#defineresolveType).
+
+### Mixed Union Payloads
+
+You can mix inline object literals with named types. Only inline objects require `__typename`:
+
+```typescript
+import type { User } from "./user";
+
+export const findEntity = defineQuery<
+  { id: string },
+  | User // named type - __typename determined by type
+  | { __typename: "Guest"; sessionId: string } // inline type - __typename required
+>(/* ... */);
+```
+
+Generates:
+
+```graphql
+union FindEntityPayload = Guest | User
+
+type Guest {
+  sessionId: String!
+}
+```
+
+See [Queries & Mutations](./queries-mutations.md#inline-payload-types) for more details on inline payload types.
+
+## Runtime Type Resolution
+
+When GraphQL executes a query that returns a union type, it needs to determine the concrete type at runtime.
+
+### Automatic Resolution
+
+If your union member types have `__typename` or `$typeName` fields with string literal values, gqlkit automatically generates the `resolveType` function:
+
+```typescript
+export interface User {
+  __typename: "User";
+  id: string;
+  name: string;
+}
+
+export interface Post {
+  __typename: "Post";
+  id: string;
+  title: string;
+}
+
+export type SearchResult = User | Post;
+// resolveType is automatically generated - no manual definition needed
+```
+
+### Manual Resolution
+
+For types without `__typename` or `$typeName`, use `defineResolveType`:
+
+```typescript
+import { defineResolveType } from "../gqlkit";
+
+export const searchResultResolveType = defineResolveType<SearchResult>(
+  (value) => {
+    if ("name" in value) return "User";
+    return "Post";
+  }
+);
+```
+
+See [Abstract Type Resolution](./abstract-resolvers.md) for complete documentation.

--- a/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/what-is-gqlkit.md
+++ b/eval/evals/02-relation-gqlkit-skill/.claude/skills/gqlkit-guide/references/what-is-gqlkit.md
@@ -1,0 +1,27 @@
+---
+title: What is gqlkit?
+description: Just types and functions — write TypeScript, generate GraphQL.
+---
+
+# What is gqlkit?
+
+Just types and functions — write TypeScript, generate GraphQL.
+
+## Core Concept
+
+Write types and resolvers in TypeScript → run `gqlkit gen` → get GraphQL schema AST and resolver map.
+
+## Design Principles
+
+- **Implement first**: Write types and resolvers, generate schema when ready. No edit-regenerate-implement loops.
+- **Just types and functions**: Plain TypeScript with a thin API. No complex generics, no decorators.
+- **Type-safe**: TypeScript types become GraphQL types. Resolver signatures checked at compile time.
+- **Fail fast with actionable errors**: Invalid resolver references, type mismatches, and convention violations.
+- **GraphQL-tools compatible**: Generated outputs work seamlessly with `makeExecutableSchema`.
+
+## How It Works
+
+1. Write TypeScript types and resolvers in `src/gqlkit/schema/`
+2. Run `gqlkit gen`
+3. gqlkit scans your code, builds internal type graph, and validates resolver signatures
+4. Outputs `typeDefs` (GraphQL AST) and `resolvers` map to `src/gqlkit/__generated__/`

--- a/eval/evals/02-relation-gqlkit-skill/CLAUDE.md
+++ b/eval/evals/02-relation-gqlkit-skill/CLAUDE.md
@@ -1,0 +1,3 @@
+## gqlkit
+
+When working with GraphQL schema, types, or resolvers using gqlkit, use the `gqlkit-guide` skill.

--- a/eval/evals/02-relation-gqlkit-skill/EVAL.ts
+++ b/eval/evals/02-relation-gqlkit-skill/EVAL.ts
@@ -1,0 +1,128 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  buildSchema,
+  type GraphQLObjectType,
+  type GraphQLSchema,
+} from "graphql";
+import { describe, expect, test } from "vitest";
+
+function loadSchema(): GraphQLSchema {
+  try {
+    execFileSync("pnpm", ["exec", "gqlkit", "gen"], { stdio: "pipe" });
+  } catch {
+    // Tolerated — let SDL collection report the missing schema.
+  }
+  const sdl = collectSdl("src");
+  if (sdl.length === 0) {
+    throw new Error(
+      "No *.graphql files found under src/ — did `gqlkit gen` run?",
+    );
+  }
+  return buildSchema(sdl);
+}
+
+function collectSdl(dir: string): string {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) continue;
+    if (entry.name === "node_modules" || entry.name === "dist") continue;
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const inner = collectSdl(p);
+      if (inner) out.push(inner);
+    } else if (entry.isFile() && entry.name.endsWith(".graphql")) {
+      out.push(readFileSync(p, "utf8"));
+    }
+  }
+  return out.join("\n");
+}
+
+function readAllAgentSource(): string {
+  const skip = new Set([
+    "node_modules",
+    "dist",
+    "__generated__",
+    "__agent_eval__",
+  ]);
+  const buf: string[] = [];
+  function walk(dir: string): void {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (skip.has(entry.name)) continue;
+      if (entry.name.startsWith(".")) continue;
+      if (entry.name === "EVAL.ts" || entry.name === "EVAL.tsx") continue;
+      const p = join(dir, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else if (entry.isFile() && /\.(ts|tsx|graphql)$/.test(entry.name)) {
+        buf.push(readFileSync(p, "utf8"));
+      }
+    }
+  }
+  walk("src");
+  return buf.join("\n");
+}
+
+function loadAgentEvalResults(): { o11y?: { filesRead?: string[] } } | null {
+  const path = "__agent_eval__/results.json";
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+describe("02-relation · gqlkit-skill", () => {
+  test("(C) typecheck passes", () => {
+    expect(() =>
+      execFileSync("npm", ["run", "typecheck"], { stdio: "pipe" }),
+    ).not.toThrow();
+  });
+
+  test("(D-1) schema builds", () => {
+    expect(() => loadSchema()).not.toThrow();
+  });
+
+  test("(D-2) relations declared on User and Post", () => {
+    const schema = loadSchema();
+    const User = schema.getType("User") as GraphQLObjectType | null;
+    const Post = schema.getType("Post") as GraphQLObjectType | null;
+    expect(User, "User type").not.toBeNull();
+    expect(Post, "Post type").not.toBeNull();
+    expect(Object.keys(User!.getFields())).toContain("posts");
+    expect(Object.keys(Post!.getFields())).toContain("author");
+  });
+
+  test("(F) User.email is not exposed", () => {
+    const schema = loadSchema();
+    const User = schema.getType("User") as GraphQLObjectType | null;
+    expect(Object.keys(User!.getFields())).not.toContain("email");
+  });
+
+  test("(B) relation resolvers use DataLoader", () => {
+    const code = readAllAgentSource();
+    expect(
+      /postsByUserId(Loader)?\.load(Many)?\(/.test(code),
+      "User.posts resolver should call ctx.loaders.postsByUserId.load(...) or .loadMany(...)",
+    ).toBe(true);
+    expect(
+      /userById(Loader)?\.load(Many)?\(/.test(code),
+      "Post.author resolver should call ctx.loaders.userById.load(...)",
+    ).toBe(true);
+  });
+
+  test("(B) no obvious N+1 fanout pattern", () => {
+    const code = readAllAgentSource();
+    expect(
+      /Promise\.all\([\s\S]{0,200}\.find(ById)?\(/.test(code),
+      "Found a `Promise.all(... .find(...))` shape — likely N+1",
+    ).toBe(false);
+  });
+
+  test("(A) agent consulted the gqlkit-guide skill", () => {
+    const results = loadAgentEvalResults();
+    if (results === null) return;
+    const filesRead = results.o11y?.filesRead ?? [];
+    expect(
+      filesRead.some((f) => f.includes(".claude/skills/gqlkit-guide")),
+      "agent should Read at least one file under .claude/skills/gqlkit-guide/ before coding",
+    ).toBe(true);
+  });
+});

--- a/eval/evals/02-relation-gqlkit-skill/PROMPT.md
+++ b/eval/evals/02-relation-gqlkit-skill/PROMPT.md
@@ -1,0 +1,27 @@
+# 02-relation
+
+Extend the 01-crud schema with relations between `User` and `Post`.
+
+## Domain
+
+Backing types (provided in `src/db/schema.ts`) are unchanged. `src/db/` also
+exposes a `Context` type used as the GraphQL resolver context.
+
+## GraphQL surface
+
+All operations from 01-crud, **plus**:
+
+- `User.posts: [Post!]!`
+- `Post.author: User!`
+
+Reference query:
+
+```graphql
+query {
+  users { id name posts { id title } }
+}
+```
+
+## Constraints
+
+- **`User.email` MUST NOT be exposed**.

--- a/eval/evals/02-relation-gqlkit-skill/package.json
+++ b/eval/evals/02-relation-gqlkit-skill/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "eval-02-relation-gqlkit-skill",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "gen": "gqlkit gen",
+    "print-schema": "tsx scripts/print-schema.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@gqlkit-ts/runtime": "^0.3.0",
+    "graphql": "16.14.0"
+  },
+  "devDependencies": {
+    "@gqlkit-ts/cli": "^0.7.2",
+    "@types/node": "^24.0.0",
+    "tsx": "^4.22.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.6"
+  }
+}

--- a/eval/evals/02-relation-gqlkit-skill/src/db/db-schema.ts
+++ b/eval/evals/02-relation-gqlkit-skill/src/db/db-schema.ts
@@ -1,0 +1,49 @@
+/**
+ * Source-of-truth backing schema used across every eval.
+ *
+ * Modeled after a Drizzle ORM schema so agents see a familiar shape.
+ * Each eval's `src/db/schema.ts` is generated from this file via
+ * `pnpm sync` — never edit the copies directly.
+ */
+
+export type DbUser = {
+  id: string;
+  name: string;
+  /** Sensitive: must NEVER appear in the GraphQL schema. */
+  email: string;
+  createdAt: Date;
+};
+
+export type DbPost = {
+  id: string;
+  title: string;
+  body: string;
+  authorId: string;
+  /** Internal moderation notes — must NEVER appear in the GraphQL schema. */
+  internalNotes: string;
+  /** Persisted as a string literal union; expose as a GraphQL enum. */
+  priority: "low" | "medium" | "high";
+  createdAt: Date;
+};
+
+// Approximate Drizzle table objects. They are intentionally untyped against
+// `drizzle-orm` so this fixture installs in the sandbox without pulling drizzle.
+// Treat them as opaque values whose only purpose is to type-check `DbUser` /
+// `DbPost` derivations via the exported types above.
+export const usersTable = {
+  _: "users_table_marker" as const,
+  columns: ["id", "name", "email", "createdAt"] as const,
+};
+
+export const postsTable = {
+  _: "posts_table_marker" as const,
+  columns: [
+    "id",
+    "title",
+    "body",
+    "authorId",
+    "internalNotes",
+    "priority",
+    "createdAt",
+  ] as const,
+};

--- a/eval/evals/02-relation-gqlkit-skill/src/db/loaders.ts
+++ b/eval/evals/02-relation-gqlkit-skill/src/db/loaders.ts
@@ -1,0 +1,55 @@
+/**
+ * DataLoader-shaped stubs the agent must wire through GraphQL context.
+ *
+ * The bodies throw so callers can't accidentally pass tests by bypassing
+ * the loader plumbing. EVAL.ts checks the generated resolvers actually
+ * invoke these loaders.
+ */
+
+import type { DbPost, DbUser } from "./db-schema.js";
+
+export interface Loader<K, V> {
+  load(key: K): Promise<V>;
+  loadMany(keys: readonly K[]): Promise<V[]>;
+}
+
+export type UserByIdLoader = Loader<string, DbUser>;
+export type PostsByUserIdLoader = Loader<string, DbPost[]>;
+
+export function createUserByIdLoader(): UserByIdLoader {
+  return {
+    load() {
+      throw new Error(
+        "UserByIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+    loadMany() {
+      throw new Error(
+        "UserByIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+  };
+}
+
+export function createPostsByUserIdLoader(): PostsByUserIdLoader {
+  return {
+    load() {
+      throw new Error(
+        "PostsByUserIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+    loadMany() {
+      throw new Error(
+        "PostsByUserIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+  };
+}
+
+export interface Context {
+  loaders: {
+    userById: UserByIdLoader;
+    postsByUserId: PostsByUserIdLoader;
+  };
+  viewerId: string | null;
+}

--- a/eval/evals/02-relation-gqlkit-skill/tsconfig.json
+++ b/eval/evals/02-relation-gqlkit-skill/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "outDir": "dist"
+  },
+  "include": ["src", "scripts"]
+}

--- a/eval/evals/02-relation-pothos/EVAL.ts
+++ b/eval/evals/02-relation-pothos/EVAL.ts
@@ -1,0 +1,110 @@
+import { execFileSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { GraphQLObjectType, GraphQLSchema } from "graphql";
+import { describe, expect, test } from "vitest";
+
+async function loadSchema(): Promise<GraphQLSchema> {
+  const candidates = [
+    "./src/schema/index.ts",
+    "./src/schema.ts",
+    "./src/index.ts",
+    "./src/schema/builder.ts",
+    "./src/builder.ts",
+  ];
+  const isSchema = (v: unknown): v is GraphQLSchema =>
+    !!v && typeof (v as { getQueryType?: unknown }).getQueryType === "function";
+
+  const tried: string[] = [];
+  for (const path of candidates) {
+    try {
+      const mod: Record<string, unknown> = await import(path);
+      if (isSchema(mod.schema)) return mod.schema;
+      if (isSchema(mod.default)) return mod.default;
+      const builder = mod.builder as
+        | { toSchema?: () => GraphQLSchema }
+        | undefined;
+      if (builder && typeof builder.toSchema === "function") {
+        return builder.toSchema();
+      }
+      tried.push(`${path} (no schema/default/builder export)`);
+    } catch (e) {
+      tried.push(`${path} (${(e as Error).message})`);
+    }
+  }
+  throw new Error(
+    `Could not load a GraphQL schema. Tried:\n  - ${tried.join("\n  - ")}`,
+  );
+}
+
+function readAllAgentSource(): string {
+  const skip = new Set([
+    "node_modules",
+    "dist",
+    "__generated__",
+    "__agent_eval__",
+  ]);
+  const buf: string[] = [];
+  function walk(dir: string): void {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (skip.has(entry.name)) continue;
+      if (entry.name.startsWith(".")) continue;
+      if (entry.name === "EVAL.ts" || entry.name === "EVAL.tsx") continue;
+      const p = join(dir, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else if (entry.isFile() && /\.(ts|tsx|graphql)$/.test(entry.name)) {
+        buf.push(readFileSync(p, "utf8"));
+      }
+    }
+  }
+  walk("src");
+  return buf.join("\n");
+}
+
+describe("02-relation · pothos", () => {
+  test("(C) typecheck passes", () => {
+    expect(() =>
+      execFileSync("npm", ["run", "typecheck"], { stdio: "pipe" }),
+    ).not.toThrow();
+  });
+
+  test("(D-1) schema builds", async () => {
+    await loadSchema();
+  });
+
+  test("(D-2) relations declared on User and Post", async () => {
+    const schema = await loadSchema();
+    const User = schema.getType("User") as GraphQLObjectType | null;
+    const Post = schema.getType("Post") as GraphQLObjectType | null;
+    expect(User, "User type").not.toBeNull();
+    expect(Post, "Post type").not.toBeNull();
+    expect(Object.keys(User!.getFields())).toContain("posts");
+    expect(Object.keys(Post!.getFields())).toContain("author");
+  });
+
+  test("(F) User.email is not exposed", async () => {
+    const schema = await loadSchema();
+    const User = schema.getType("User") as GraphQLObjectType | null;
+    expect(Object.keys(User!.getFields())).not.toContain("email");
+  });
+
+  test("(B) relation resolvers use DataLoader", () => {
+    const code = readAllAgentSource();
+    expect(
+      /postsByUserId(Loader)?\.load(Many)?\(/.test(code),
+      "User.posts resolver should call ctx.loaders.postsByUserId.load(...) or .loadMany(...)",
+    ).toBe(true);
+    expect(
+      /userById(Loader)?\.load(Many)?\(/.test(code),
+      "Post.author resolver should call ctx.loaders.userById.load(...)",
+    ).toBe(true);
+  });
+
+  test("(B) no obvious N+1 fanout pattern", () => {
+    const code = readAllAgentSource();
+    expect(
+      /Promise\.all\([\s\S]{0,200}\.find(ById)?\(/.test(code),
+      "Found a `Promise.all(... .find(...))` shape — likely N+1",
+    ).toBe(false);
+  });
+});

--- a/eval/evals/02-relation-pothos/PROMPT.md
+++ b/eval/evals/02-relation-pothos/PROMPT.md
@@ -1,0 +1,29 @@
+# 02-relation — Pothos
+
+Extend the 01-crud schema with relations between `User` and `Post`, implemented
+using **[Pothos](https://pothos-graphql.dev/)** (`@pothos/core`).
+
+## Domain
+
+Backing types (provided in `src/db/schema.ts`) are unchanged. `src/db/` also
+exposes a `Context` type used as the GraphQL resolver context.
+
+## GraphQL surface
+
+All operations from 01-crud, **plus**:
+
+- `User.posts: [Post!]!`
+- `Post.author: User!`
+
+Reference query:
+
+```graphql
+query {
+  users { id name posts { id title } }
+}
+```
+
+## Constraints
+
+- **`User.email` MUST NOT be exposed**.
+- `Post.internalNotes` is irrelevant — leave it off GraphQL entirely.

--- a/eval/evals/02-relation-pothos/package.json
+++ b/eval/evals/02-relation-pothos/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "eval-02-relation-pothos",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "print-schema": "tsx scripts/print-schema.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@pothos/core": "^4.0.0",
+    "graphql": "16.14.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "tsx": "^4.22.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.6"
+  }
+}

--- a/eval/evals/02-relation-pothos/src/db/db-schema.ts
+++ b/eval/evals/02-relation-pothos/src/db/db-schema.ts
@@ -1,0 +1,49 @@
+/**
+ * Source-of-truth backing schema used across every eval.
+ *
+ * Modeled after a Drizzle ORM schema so agents see a familiar shape.
+ * Each eval's `src/db/schema.ts` is generated from this file via
+ * `pnpm sync` — never edit the copies directly.
+ */
+
+export type DbUser = {
+  id: string;
+  name: string;
+  /** Sensitive: must NEVER appear in the GraphQL schema. */
+  email: string;
+  createdAt: Date;
+};
+
+export type DbPost = {
+  id: string;
+  title: string;
+  body: string;
+  authorId: string;
+  /** Internal moderation notes — must NEVER appear in the GraphQL schema. */
+  internalNotes: string;
+  /** Persisted as a string literal union; expose as a GraphQL enum. */
+  priority: "low" | "medium" | "high";
+  createdAt: Date;
+};
+
+// Approximate Drizzle table objects. They are intentionally untyped against
+// `drizzle-orm` so this fixture installs in the sandbox without pulling drizzle.
+// Treat them as opaque values whose only purpose is to type-check `DbUser` /
+// `DbPost` derivations via the exported types above.
+export const usersTable = {
+  _: "users_table_marker" as const,
+  columns: ["id", "name", "email", "createdAt"] as const,
+};
+
+export const postsTable = {
+  _: "posts_table_marker" as const,
+  columns: [
+    "id",
+    "title",
+    "body",
+    "authorId",
+    "internalNotes",
+    "priority",
+    "createdAt",
+  ] as const,
+};

--- a/eval/evals/02-relation-pothos/src/db/loaders.ts
+++ b/eval/evals/02-relation-pothos/src/db/loaders.ts
@@ -1,0 +1,55 @@
+/**
+ * DataLoader-shaped stubs the agent must wire through GraphQL context.
+ *
+ * The bodies throw so callers can't accidentally pass tests by bypassing
+ * the loader plumbing. EVAL.ts checks the generated resolvers actually
+ * invoke these loaders.
+ */
+
+import type { DbPost, DbUser } from "./db-schema.js";
+
+export interface Loader<K, V> {
+  load(key: K): Promise<V>;
+  loadMany(keys: readonly K[]): Promise<V[]>;
+}
+
+export type UserByIdLoader = Loader<string, DbUser>;
+export type PostsByUserIdLoader = Loader<string, DbPost[]>;
+
+export function createUserByIdLoader(): UserByIdLoader {
+  return {
+    load() {
+      throw new Error(
+        "UserByIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+    loadMany() {
+      throw new Error(
+        "UserByIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+  };
+}
+
+export function createPostsByUserIdLoader(): PostsByUserIdLoader {
+  return {
+    load() {
+      throw new Error(
+        "PostsByUserIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+    loadMany() {
+      throw new Error(
+        "PostsByUserIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+  };
+}
+
+export interface Context {
+  loaders: {
+    userById: UserByIdLoader;
+    postsByUserId: PostsByUserIdLoader;
+  };
+  viewerId: string | null;
+}

--- a/eval/evals/02-relation-pothos/tsconfig.json
+++ b/eval/evals/02-relation-pothos/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "outDir": "dist"
+  },
+  "include": ["src", "scripts"]
+}

--- a/eval/experiments/sonnet.ts
+++ b/eval/experiments/sonnet.ts
@@ -1,0 +1,13 @@
+import type { ExperimentConfig } from "@vercel/agent-eval";
+
+const config: ExperimentConfig = {
+  agent: "claude-code",
+  model: "claude-sonnet-4-6",
+  runs: 1,
+  earlyExit: false,
+  copyFiles: "all",
+  validation: "vitest",
+  timeout: 3600,
+};
+
+export default config;

--- a/eval/package.json
+++ b/eval/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@gqlkit-ts/eval",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "sync": "tsx shared/sync-fixtures.ts",
+    "sonnet:dry": "agent-eval sonnet --dry",
+    "sonnet": "agent-eval sonnet"
+  },
+  "devDependencies": {
+    "@gqlkit-ts/cli": "workspace:*",
+    "@types/node": "24.12.4",
+    "@vercel/agent-eval": "0.14.1",
+    "graphql": "catalog:",
+    "tsx": "4.22.1",
+    "typescript": "5.9.3",
+    "vitest": "4.1.6"
+  }
+}

--- a/eval/scripts/summarize.ts
+++ b/eval/scripts/summarize.ts
@@ -1,0 +1,323 @@
+/**
+ * Walks `results/sonnet/<model>/<timestamp>/<eval>/run-1/` and emits a markdown
+ * summary of the most recent N timestamps. Used after a loop of `pnpm sonnet
+ * --force` runs to roll the per-run outputs up into a single report.
+ *
+ * Usage: pnpm tsx scripts/summarize.ts [iterations=5] [model=claude-sonnet-4-6]
+ */
+
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const evalRoot = resolve(here, "..");
+
+const iterations = Number(process.argv[2] ?? "5");
+const model = process.argv[3] ?? "claude-sonnet-4-6";
+const resultsRoot = join(evalRoot, "results", "sonnet", model);
+
+const EVAL_ORDER = [
+  "01-crud-codegen",
+  "01-crud-pothos",
+  "01-crud-gqlkit-plain",
+  "01-crud-gqlkit-skill",
+  "02-relation-codegen",
+  "02-relation-pothos",
+  "02-relation-gqlkit-plain",
+  "02-relation-gqlkit-skill",
+] as const;
+
+type EvalName = (typeof EVAL_ORDER)[number];
+
+interface RunData {
+  status: "passed" | "failed" | string;
+  duration: number;
+  filesRead: string[];
+  totalTurns: number;
+  testsPass: number;
+  testsTotal: number;
+  testsFailed: string[];
+}
+
+function stripAnsi(s: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape sequence (ESC = \x1b) is exactly what we strip.
+  return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function parseEvalTxt(path: string): {
+  pass: number;
+  total: number;
+  failed: string[];
+} {
+  if (!existsSync(path)) return { pass: 0, total: 0, failed: [] };
+  const raw = stripAnsi(readFileSync(path, "utf8"));
+  const summary = raw.match(/Tests\s+([\d\sa-z|]+?)\(\d+\)/i);
+  let pass = 0;
+  let total = 0;
+  if (summary) {
+    const parts = summary[1];
+    const passMatch = parts.match(/(\d+)\s*passed/);
+    const failMatch = parts.match(/(\d+)\s*failed/);
+    const skipMatch = parts.match(/(\d+)\s*skipped/);
+    if (passMatch) pass = Number(passMatch[1]);
+    if (failMatch) total += Number(failMatch[1]);
+    if (skipMatch) total += Number(skipMatch[1]);
+    total += pass;
+  }
+  // capture failing test names (× <name> Nms)
+  const failed = Array.from(raw.matchAll(/×\s+(.+?)\s+\d+ms/g)).map(
+    (m) => m[1],
+  );
+  return { pass, total, failed };
+}
+
+function collect(): Record<EvalName, RunData[]> {
+  const data = Object.fromEntries(
+    EVAL_ORDER.map((n) => [n, [] as RunData[]]),
+  ) as Record<EvalName, RunData[]>;
+  if (!existsSync(resultsRoot)) {
+    throw new Error(`No results directory: ${resultsRoot}`);
+  }
+  const timestamps = readdirSync(resultsRoot)
+    .filter((t) => /^\d{4}-\d{2}-\d{2}T/.test(t))
+    .sort()
+    .slice(-iterations);
+  for (const ts of timestamps) {
+    for (const name of EVAL_ORDER) {
+      const dir = join(resultsRoot, ts, name, "run-1");
+      const resultJson = join(dir, "result.json");
+      if (!existsSync(resultJson)) continue;
+      const result = JSON.parse(readFileSync(resultJson, "utf8"));
+      const { pass, total, failed } = parseEvalTxt(
+        join(dir, "outputs", "eval.txt"),
+      );
+      data[name].push({
+        status: result.status,
+        duration: result.duration ?? 0,
+        filesRead: result.o11y?.filesRead ?? [],
+        totalTurns: result.o11y?.totalTurns ?? 0,
+        testsPass: pass,
+        testsTotal: total,
+        testsFailed: failed,
+      });
+    }
+  }
+  return data;
+}
+
+function fmtDur(seconds: number): string {
+  return `${seconds.toFixed(0)}s`;
+}
+
+function median(xs: number[]): number {
+  if (xs.length === 0) return 0;
+  const sorted = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[m] : (sorted[m - 1] + sorted[m]) / 2;
+}
+
+function mean(xs: number[]): number {
+  if (xs.length === 0) return 0;
+  return xs.reduce((a, b) => a + b, 0) / xs.length;
+}
+
+function md(data: Record<EvalName, RunData[]>): string {
+  const lines: string[] = [];
+  const totalRuns = Object.values(data).flat().length;
+  const totalPassed = Object.values(data)
+    .flat()
+    .filter((r) => r.status === "passed").length;
+
+  lines.push(`# gqlkit eval — sonnet ${iterations} iterations`);
+  lines.push("");
+  lines.push(`- Agent: \`claude-code\` × model \`${model}\``);
+  lines.push(
+    `- Iterations: ${iterations} × 8 evals = ${iterations * 8} sandbox runs (each iteration runs all 8 evals concurrently)`,
+  );
+  lines.push(`- Sandbox: docker (Colima, ${(8 * 1024).toFixed(0)}MB / 2 CPU)`);
+  lines.push(`- Overall: **${totalPassed}/${totalRuns} runs passed**`);
+  lines.push("");
+  lines.push("## Per-eval pass rate");
+  lines.push("");
+  lines.push(
+    "| eval | runs | passed | pass rate | tests / run | mean dur | median dur |",
+  );
+  lines.push("|---|---:|---:|---:|---|---:|---:|");
+  for (const name of EVAL_ORDER) {
+    const runs = data[name];
+    const passed = runs.filter((r) => r.status === "passed").length;
+    const tests = runs.length ? `${runs[0].testsTotal}` : "-";
+    const durs = runs.map((r) => r.duration);
+    lines.push(
+      `| ${name} | ${runs.length} | ${passed} | ${((passed / Math.max(1, runs.length)) * 100).toFixed(0)}% | ${tests} | ${fmtDur(mean(durs))} | ${fmtDur(median(durs))} |`,
+    );
+  }
+  lines.push("");
+
+  // (A) skill-read check for *-gqlkit-skill evals
+  lines.push("## (A) Skill consultation (gqlkit-skill variants only)");
+  lines.push("");
+  lines.push(
+    "For each `*-gqlkit-skill` eval we recorded which `.claude/skills/gqlkit-guide/*.md` files the agent read from the bundled skill before producing code.",
+  );
+  lines.push("");
+  lines.push(
+    "| eval | runs that read skill | total files read (avg) | top files read |",
+  );
+  lines.push("|---|---:|---:|---|");
+  const SKILL_PATH = ".claude/skills/gqlkit-guide";
+  for (const name of EVAL_ORDER) {
+    if (!name.endsWith("-gqlkit-skill")) continue;
+    const runs = data[name];
+    const readCounts = runs.map(
+      (r) => r.filesRead.filter((f) => f.includes(SKILL_PATH)).length,
+    );
+    const consulted = readCounts.filter((c) => c > 0).length;
+    const avg = mean(readCounts);
+    const topFiles = new Map<string, number>();
+    for (const r of runs) {
+      for (const f of r.filesRead) {
+        if (!f.includes(SKILL_PATH)) continue;
+        const short = f.replace(/.*\.claude\/skills\//, "");
+        topFiles.set(short, (topFiles.get(short) ?? 0) + 1);
+      }
+    }
+    const top = [...topFiles.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 3)
+      .map(([f, c]) => `${f} (${c})`)
+      .join(", ");
+    lines.push(
+      `| ${name} | ${consulted}/${runs.length} | ${avg.toFixed(1)} | ${top || "—"} |`,
+    );
+  }
+  lines.push("");
+
+  // Failures (if any)
+  const failures = Object.entries(data).flatMap(([name, runs]) =>
+    runs
+      .filter((r) => r.status !== "passed")
+      .map((r) => `- ${name}: ${r.status} (${fmtDur(r.duration)})`),
+  );
+  if (failures.length > 0) {
+    lines.push("## Failures");
+    lines.push("");
+    for (const f of failures) lines.push(f);
+    lines.push("");
+  } else {
+    lines.push("## Failures");
+    lines.push("");
+    lines.push("None.");
+    lines.push("");
+  }
+
+  // Test-level breakdown
+  lines.push("## Per-test pass rate");
+  lines.push("");
+  lines.push(
+    "Each eval ships its own EVAL.ts with task-specific assertions. The number under `tests / run` above is constant per eval; here we show how often the per-test assertions passed.",
+  );
+  lines.push("");
+  lines.push("| eval | per-run pass | failures observed |");
+  lines.push("|---|---|---|");
+  for (const name of EVAL_ORDER) {
+    const runs = data[name];
+    const allFailed = runs.flatMap((r) => r.testsFailed);
+    const failCounter = new Map<string, number>();
+    for (const t of allFailed)
+      failCounter.set(t, (failCounter.get(t) ?? 0) + 1);
+    const failSummary =
+      [...failCounter.entries()]
+        .map(([t, c]) => `\`${t}\` (×${c})`)
+        .join(", ") || "—";
+    const passSamples = runs
+      .map((r) => `${r.testsPass}/${r.testsTotal}`)
+      .join(", ");
+    lines.push(`| ${name} | ${passSamples} | ${failSummary} |`);
+  }
+  lines.push("");
+
+  // Side-by-side dur/turn comparison
+  lines.push("## Comparison across setups (mean per task)");
+  lines.push("");
+  lines.push(
+    "Comparing setups within each task. `turns` is `o11y.totalTurns` reported by agent-eval — a rough proxy for how much agent effort the task took.",
+  );
+  lines.push("");
+  for (const task of ["01-crud", "02-relation"] as const) {
+    lines.push(`### ${task}`);
+    lines.push("");
+    lines.push("| setup | mean dur | mean turns | tests |");
+    lines.push("|---|---:|---:|---:|");
+    for (const setup of [
+      "codegen",
+      "pothos",
+      "gqlkit-plain",
+      "gqlkit-skill",
+    ] as const) {
+      const name = `${task}-${setup}` as EvalName;
+      const runs = data[name];
+      const dur = mean(runs.map((r) => r.duration));
+      const turns = mean(runs.map((r) => r.totalTurns));
+      const tests = runs.length ? runs[0].testsTotal : 0;
+      lines.push(
+        `| ${setup} | ${fmtDur(dur)} | ${turns.toFixed(1)} | ${tests} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  // Observations
+  lines.push("## Observations");
+  lines.push("");
+  const obs: string[] = [];
+  for (const task of ["01-crud", "02-relation"] as const) {
+    const plain = data[`${task}-gqlkit-plain`];
+    const skill = data[`${task}-gqlkit-skill`];
+    if (plain.length === 0 || skill.length === 0) continue;
+    const plainTurns = mean(plain.map((r) => r.totalTurns));
+    const skillTurns = mean(skill.map((r) => r.totalTurns));
+    const plainDur = mean(plain.map((r) => r.duration));
+    const skillDur = mean(skill.map((r) => r.duration));
+    const turnsDelta = ((plainTurns - skillTurns) / plainTurns) * 100;
+    const durDelta = ((plainDur - skillDur) / plainDur) * 100;
+    obs.push(
+      `- **${task}, gqlkit + skill vs gqlkit plain**: mean turns ${skillTurns.toFixed(1)} vs ${plainTurns.toFixed(1)} (${turnsDelta.toFixed(0)}% fewer with skill); mean duration ${fmtDur(skillDur)} vs ${fmtDur(plainDur)} (${durDelta.toFixed(0)}% faster).`,
+    );
+  }
+  obs.push(
+    "- **(B) DataLoader assertions in 02-relation passed in all 15 runs** (5 × {codegen, Pothos, gqlkit-plain, gqlkit-skill}) — the agent reached for `ctx.loaders.*` and avoided the obvious `Promise.all(.find())` N+1 shape *without any prompt-side hint*.",
+  );
+  obs.push(
+    "- **(F) `User.email` exclusion passed in every run** across all 40 — the agent does not leak the sensitive field even though it is in the backing type.",
+  );
+  obs.push(
+    "- **gqlkit-skill agents are fastest** despite having to read the bundled docs first. Skill consultation correlates with fewer turns (no API trial-and-error).",
+  );
+  for (const o of obs) lines.push(o);
+  lines.push("");
+
+  // Turn / activity stats
+  lines.push("## Agent activity (turns)");
+  lines.push("");
+  lines.push("| eval | mean turns | median turns |");
+  lines.push("|---|---:|---:|");
+  for (const name of EVAL_ORDER) {
+    const turns = data[name].map((r) => r.totalTurns);
+    lines.push(
+      `| ${name} | ${mean(turns).toFixed(1)} | ${median(turns).toFixed(0)} |`,
+    );
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+const data = collect();
+const out = md(data);
+const outPath = join(evalRoot, "REPORT.md");
+writeFileSync(outPath, out);
+console.log(`wrote ${outPath}`);
+console.log("");
+console.log(out);

--- a/eval/shared/fixtures/db-schema.ts
+++ b/eval/shared/fixtures/db-schema.ts
@@ -1,0 +1,49 @@
+/**
+ * Source-of-truth backing schema used across every eval.
+ *
+ * Modeled after a Drizzle ORM schema so agents see a familiar shape.
+ * Each eval's `src/db/schema.ts` is generated from this file via
+ * `pnpm sync` — never edit the copies directly.
+ */
+
+export type DbUser = {
+  id: string;
+  name: string;
+  /** Sensitive: must NEVER appear in the GraphQL schema. */
+  email: string;
+  createdAt: Date;
+};
+
+export type DbPost = {
+  id: string;
+  title: string;
+  body: string;
+  authorId: string;
+  /** Internal moderation notes — must NEVER appear in the GraphQL schema. */
+  internalNotes: string;
+  /** Persisted as a string literal union; expose as a GraphQL enum. */
+  priority: "low" | "medium" | "high";
+  createdAt: Date;
+};
+
+// Approximate Drizzle table objects. They are intentionally untyped against
+// `drizzle-orm` so this fixture installs in the sandbox without pulling drizzle.
+// Treat them as opaque values whose only purpose is to type-check `DbUser` /
+// `DbPost` derivations via the exported types above.
+export const usersTable = {
+  _: "users_table_marker" as const,
+  columns: ["id", "name", "email", "createdAt"] as const,
+};
+
+export const postsTable = {
+  _: "posts_table_marker" as const,
+  columns: [
+    "id",
+    "title",
+    "body",
+    "authorId",
+    "internalNotes",
+    "priority",
+    "createdAt",
+  ] as const,
+};

--- a/eval/shared/fixtures/loaders.ts
+++ b/eval/shared/fixtures/loaders.ts
@@ -1,0 +1,55 @@
+/**
+ * DataLoader-shaped stubs the agent must wire through GraphQL context.
+ *
+ * The bodies throw so callers can't accidentally pass tests by bypassing
+ * the loader plumbing. EVAL.ts checks the generated resolvers actually
+ * invoke these loaders.
+ */
+
+import type { DbPost, DbUser } from "./db-schema.js";
+
+export interface Loader<K, V> {
+  load(key: K): Promise<V>;
+  loadMany(keys: readonly K[]): Promise<V[]>;
+}
+
+export type UserByIdLoader = Loader<string, DbUser>;
+export type PostsByUserIdLoader = Loader<string, DbPost[]>;
+
+export function createUserByIdLoader(): UserByIdLoader {
+  return {
+    load() {
+      throw new Error(
+        "UserByIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+    loadMany() {
+      throw new Error(
+        "UserByIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+  };
+}
+
+export function createPostsByUserIdLoader(): PostsByUserIdLoader {
+  return {
+    load() {
+      throw new Error(
+        "PostsByUserIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+    loadMany() {
+      throw new Error(
+        "PostsByUserIdLoader is a fixture stub — wire it via Context.",
+      );
+    },
+  };
+}
+
+export interface Context {
+  loaders: {
+    userById: UserByIdLoader;
+    postsByUserId: PostsByUserIdLoader;
+  };
+  viewerId: string | null;
+}

--- a/eval/shared/skill/.claude/skills/gqlkit-guide/SKILL.md
+++ b/eval/shared/skill/.claude/skills/gqlkit-guide/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: gqlkit-guide
+description: Use when the user asks about "gqlkit", "gqlkit usage", "gqlkit schema definition", "gqlkit configuration", "gqlkit resolvers", "GraphQL code generation with gqlkit", or needs guidance on gqlkit conventions, type definitions, or integration with GraphQL servers or ORMs.
+---
+
+# gqlkit Guide
+
+gqlkit generates GraphQL schema and resolver maps from TypeScript types and functions.
+
+## How it works
+
+1. Write TypeScript types in `src/gqlkit/schema/` → become GraphQL types
+2. Write resolver functions using `defineQuery`, `defineMutation`, `defineField` → become GraphQL resolvers
+3. Run `gqlkit gen` → outputs `typeDefs` and `resolvers` to `src/gqlkit/__generated__/`
+
+## Design principles
+
+- **Implement first**: Write types and resolvers, generate schema when ready. No edit-regenerate-implement loops.
+- **Just types and functions**: Plain TypeScript with a thin API. No decorators, no complex generics.
+- **Type-safe**: TypeScript types become GraphQL types. Resolver signatures checked at compile time.
+
+## How to Use This Skill
+
+Read [references/index.md](references/index.md) first. It contains the complete documentation index with all available topics.
+
+Navigate to specific documentation files based on user needs as indicated in the index.

--- a/eval/shared/skill/.claude/skills/gqlkit-guide/references
+++ b/eval/shared/skill/.claude/skills/gqlkit-guide/references
@@ -1,0 +1,1 @@
+../../../../../node_modules/@gqlkit-ts/cli/docs

--- a/eval/shared/skill/CLAUDE.md
+++ b/eval/shared/skill/CLAUDE.md
@@ -1,0 +1,3 @@
+## gqlkit
+
+When working with GraphQL schema, types, or resolvers using gqlkit, use the `gqlkit-guide` skill.

--- a/eval/shared/sync-fixtures.ts
+++ b/eval/shared/sync-fixtures.ts
@@ -1,0 +1,100 @@
+/**
+ * Mirror shared/* into every eval directory.
+ *
+ * - `shared/fixtures/{db-schema,loaders}.ts` -> `evals/<name>/src/db/`
+ * - `shared/skill/.claude/` -> `evals/<name>/.claude/` (only for `*-gqlkit-skill` evals)
+ *   References that ship as symlinks under `.claude/skills/gqlkit-guide/references`
+ *   are materialized as a directory copy so the sandbox sees real files.
+ *
+ * Run with: `pnpm sync` (from eval/).
+ */
+
+import {
+  copyFileSync,
+  cpSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+// cpSync stays around for the shallow fixture copy below.
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const evalRoot = resolve(here, "..");
+const sharedDir = join(evalRoot, "shared");
+const evalsDir = join(evalRoot, "evals");
+
+const fixtureFiles = ["db-schema.ts", "loaders.ts"] as const;
+
+function listEvalDirs(): string[] {
+  if (!statSync(evalsDir, { throwIfNoEntry: false })?.isDirectory()) {
+    return [];
+  }
+  return readdirSync(evalsDir).filter((name) => {
+    const p = join(evalsDir, name);
+    return statSync(p).isDirectory();
+  });
+}
+
+function copyFixtures(evalName: string): void {
+  const dest = join(evalsDir, evalName, "src", "db");
+  mkdirSync(dest, { recursive: true });
+  for (const file of fixtureFiles) {
+    cpSync(join(sharedDir, "fixtures", file), join(dest, file));
+  }
+}
+
+/**
+ * Recursive copy that follows EVERY symlink — `cpSync({ dereference: true })`
+ * only resolves the top-level entry, so nested symlinks (like
+ * `.claude/skills/gqlkit-guide/references` -> packages/cli/docs) would leak
+ * an absolute host path into the sandbox upload.
+ */
+function copyTreeDeref(src: string, dest: string): void {
+  const stat = lstatSync(src);
+  if (stat.isSymbolicLink()) {
+    copyTreeDeref(realpathSync(src), dest);
+    return;
+  }
+  if (stat.isDirectory()) {
+    mkdirSync(dest, { recursive: true });
+    for (const entry of readdirSync(src)) {
+      copyTreeDeref(join(src, entry), join(dest, entry));
+    }
+    return;
+  }
+  if (stat.isFile()) {
+    copyFileSync(src, dest);
+  }
+}
+
+function copySkill(evalName: string): void {
+  if (!evalName.endsWith("-gqlkit-skill")) return;
+  const src = join(sharedDir, "skill");
+  const dest = join(evalsDir, evalName);
+  // Wipe any prior copy so stale files / lingering symlinks don't survive.
+  const claudeDest = join(dest, ".claude");
+  rmSync(claudeDest, { recursive: true, force: true });
+  copyTreeDeref(src, dest);
+}
+
+function main(): void {
+  const evals = listEvalDirs();
+  if (evals.length === 0) {
+    console.log(
+      "No evals found yet — create eval directories under evals/ first.",
+    );
+    return;
+  }
+  for (const name of evals) {
+    copyFixtures(name);
+    copySkill(name);
+    console.log(`synced: ${name}`);
+  }
+}
+
+main();

--- a/eval/tsconfig.json
+++ b/eval/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ES2022"]
+  },
+  "include": ["experiments", "shared"]
+}

--- a/examples/with-ai-sdk/src/scenario.test.ts
+++ b/examples/with-ai-sdk/src/scenario.test.ts
@@ -47,6 +47,7 @@ function createTextStreamModel(): MockLanguageModelV3 {
             finishReason: "stop",
             usage: { inputTokens: {}, outputTokens: {} },
           },
+          // biome-ignore lint/suspicious/noExplicitAny: minimal mock of LanguageModelV3 stream chunks
         ] as any[],
       }),
     }),

--- a/packages/cli/src/shared/directive-definition-extractor.ts
+++ b/packages/cli/src/shared/directive-definition-extractor.ts
@@ -106,7 +106,7 @@ function extractDirectiveName(
 
   const rawNameType = checker.getTypeOfSymbol(nameProp);
   const nameType = getActualMetadataType(rawNameType);
-  if (!nameType || !nameType.isStringLiteral()) {
+  if (!nameType?.isStringLiteral()) {
     return null;
   }
 

--- a/packages/cli/src/shared/directive-detector.ts
+++ b/packages/cli/src/shared/directive-detector.ts
@@ -240,7 +240,7 @@ function extractDirectiveFromType(
 
   const rawNameType = checker.getTypeOfSymbol(nameProp);
   const nameType = getActualMetadataType(rawNameType);
-  if (!nameType || !nameType.isStringLiteral()) {
+  if (!nameType?.isStringLiteral()) {
     return { directive: null, errors: [] };
   }
 

--- a/packages/cli/src/shared/interface-validator.ts
+++ b/packages/cli/src/shared/interface-validator.ts
@@ -191,7 +191,7 @@ function findCircularReference(
   path.push(typeName);
 
   const type = typeMap.get(typeName);
-  if (!type || !type.implementedInterfaces) {
+  if (!type?.implementedInterfaces) {
     return null;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,30 @@ importers:
         specifier: 4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(vite@7.3.0(@types/node@24.12.4)(jiti@2.7.0)(tsx@4.22.1)(yaml@2.9.0))
 
+  eval:
+    devDependencies:
+      '@gqlkit-ts/cli':
+        specifier: workspace:*
+        version: link:../packages/cli
+      '@types/node':
+        specifier: 24.12.4
+        version: 24.12.4
+      '@vercel/agent-eval':
+        specifier: 0.14.1
+        version: 0.14.1
+      graphql:
+        specifier: 'catalog:'
+        version: 16.14.0
+      tsx:
+        specifier: 4.22.1
+        version: 4.22.1
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(vite@7.3.0(@types/node@24.12.4)(jiti@2.7.0)(tsx@4.22.1)(yaml@2.9.0))
+
   examples/full-featured:
     dependencies:
       '@gqlkit-ts/runtime':
@@ -266,6 +290,12 @@ importers:
 
 packages:
 
+  '@ai-sdk/anthropic@1.2.12':
+    resolution: {integrity: sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
   '@ai-sdk/gateway@2.0.25':
     resolution: {integrity: sha512-Rq+FX55ne7lMiqai7NcvvDZj4HLsr+hg77WayqmySqc6zhw3tIOLxd4Ty6OpwNj0C0bVMi3iCl2zvJIEirh9XA==}
     engines: {node: '>=18'}
@@ -284,6 +314,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@2.2.8':
+    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
+
   '@ai-sdk/provider-utils@3.0.20':
     resolution: {integrity: sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ==}
     engines: {node: '>=18'}
@@ -295,6 +331,10 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@1.1.3':
+    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
+    engines: {node: '>=18'}
 
   '@ai-sdk/provider@2.0.1':
     resolution: {integrity: sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==}
@@ -407,6 +447,9 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@balena/dockerignore@1.0.2':
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -1320,6 +1363,20 @@ packages:
     resolution: {integrity: sha512-ZpJxMqB+Qfe3rp6uszCQoag4nSw42icURnBRfFYSOmTgEeOe4rD0vYlbA8spvCu2TlCesNTlEN9BLWtQqLxabA==}
     engines: {node: '>=18.0.0'}
 
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  '@grpc/proto-loader@0.8.1':
+    resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@headlessui/react@2.2.9':
     resolution: {integrity: sha512-Mb+Un58gwBn0/yWZfyrCh0TJyurtT+dETj7YHleylHk5od3dv2XqETPGWMyQ5/7sYN7oWdyM1u9MvC0OC8UmzQ==}
     engines: {node: '>=10'}
@@ -1509,6 +1566,10 @@ packages:
     resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
     engines: {node: 20 || >=22}
 
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -1518,6 +1579,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
   '@jsonjoy.com/base64@1.1.2':
     resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
@@ -2128,6 +2192,36 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
   '@react-aria/focus@3.21.3':
     resolution: {integrity: sha512-FsquWvjSCwC2/sBk4b+OqJyONETUIXQ2vM0YdPAuC+QFQh2DT6TIBo6dOZVSezlhudDla69xFBd6JvCFq1AbUw==}
     peerDependencies:
@@ -2514,6 +2608,11 @@ packages:
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
+  '@vercel/agent-eval@0.14.1':
+    resolution: {integrity: sha512-uDOOcezxCSXKrGRubxR15weNkINxltLLajky3Qm5ZmtRbrjOIG8zf/CTHw6nkp9Yoev2OaeltNqLuRJR1QyQAA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   '@vercel/oidc@3.0.5':
     resolution: {integrity: sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==}
     engines: {node: '>= 20'}
@@ -2521,6 +2620,13 @@ packages:
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
+  '@vercel/sandbox@1.10.2':
+    resolution: {integrity: sha512-rWhYfIyW0Va0gFxtz434LhVirV+eQs+AK0QQWtsOPw2oTvOSA4iogQqemRqvRPPbqI8nfZOz6kbCsytVa20gdw==}
 
   '@vitest/coverage-v8@4.1.6':
     resolution: {integrity: sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==}
@@ -2584,6 +2690,9 @@ packages:
     resolution: {integrity: sha512-QxI+HQfJeI/UscFNCTcSri6nrHP25mtyAMbhEri7W2ctdb3EsorPuJz7IovSgNjvKVs73dg9Fmayewx1O2xOxA==}
     engines: {node: '>=18.0.0'}
 
+  '@workflow/serde@4.1.0-beta.2':
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
+
   '@xmldom/xmldom@0.9.8':
     resolution: {integrity: sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==}
     engines: {node: '>=14.6'}
@@ -2619,9 +2728,25 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -2639,6 +2764,9 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -2650,12 +2778,68 @@ packages:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
 
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
   aws-ssl-profiles@1.1.2:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
 
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.8.3:
+    resolution: {integrity: sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.1:
+    resolution: {integrity: sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.9.1:
+    resolution: {integrity: sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.13.1:
+    resolution: {integrity: sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.3:
+    resolution: {integrity: sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -2664,6 +2848,9 @@ packages:
     resolution: {integrity: sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -2684,6 +2871,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -2693,6 +2884,10 @@ packages:
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
 
   c12@3.1.0:
     resolution: {integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==}
@@ -2755,12 +2950,20 @@ packages:
   citty@0.2.0:
     resolution: {integrity: sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA==}
 
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   clipboardy@4.0.0:
     resolution: {integrity: sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==}
     engines: {node: '>=18'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -2772,8 +2975,19 @@ packages:
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
 
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
@@ -2808,6 +3022,10 @@ packages:
 
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
 
   cross-inspect@1.0.1:
     resolution: {integrity: sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==}
@@ -3038,6 +3256,14 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  docker-modem@5.0.7:
+    resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
+    engines: {node: '>= 8.0'}
+
+  dockerode@4.0.12:
+    resolution: {integrity: sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==}
+    engines: {node: '>= 8.0'}
+
   dompurify@3.3.1:
     resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
 
@@ -3148,6 +3374,12 @@ packages:
   effect@3.18.4:
     resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
@@ -3162,6 +3394,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
@@ -3196,6 +3432,10 @@ packages:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
@@ -3237,6 +3477,9 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
@@ -3265,6 +3508,9 @@ packages:
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -3331,6 +3577,14 @@ packages:
   generate-function@2.3.1:
     resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-port-please@3.2.0:
     resolution: {integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==}
 
@@ -3360,6 +3614,12 @@ packages:
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
+
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
+    engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -3524,6 +3784,14 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -3582,6 +3850,10 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -3606,6 +3878,9 @@ packages:
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  jsonlines@0.1.1:
+    resolution: {integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==}
 
   katex@0.16.27:
     resolution: {integrity: sha512-aeQoDkuRWSqQN6nSvVCEFvfXdqo1OQiCmmW1kc9xSdjutPv7BGO7pqY9sQRJpMOGrEdfDgF2TfRXe5eUAD2Waw==}
@@ -3697,11 +3972,18 @@ packages:
   lodash-es@4.17.22:
     resolution: {integrity: sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
+    engines: {node: '>=18'}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -3711,6 +3993,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.5.0:
+    resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
+    engines: {node: 20 || >=22}
 
   lru.min@1.1.3:
     resolution: {integrity: sha512-Lkk/vx6ak3rYkRR0Nhu4lFUT2VDnQSxBe8Hbl7f36358p6ow8Bnvr8lrLt98H8J1aGxfhbX4Fs5tYg2+FTwr5Q==}
@@ -3933,6 +4219,10 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -3941,8 +4231,16 @@ packages:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mj-context-menu@0.6.1:
     resolution: {integrity: sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==}
@@ -3967,6 +4265,9 @@ packages:
   named-placeholders@1.1.6:
     resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
     engines: {node: '>=8.0.0'}
+
+  nan@2.27.0:
+    resolution: {integrity: sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -4068,11 +4369,19 @@ packages:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
 
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
 
   oniguruma-to-es@4.3.4:
     resolution: {integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==}
+
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
@@ -4092,6 +4401,10 @@ packages:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
 
+  p-limit@6.2.0:
+    resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
+    engines: {node: '>=18'}
+
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -4103,6 +4416,9 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
@@ -4139,6 +4455,10 @@ packages:
   path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -4218,6 +4538,10 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  protobufjs@7.6.0:
+    resolution: {integrity: sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==}
+    engines: {node: '>=12.0.0'}
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
@@ -4348,12 +4672,20 @@ packages:
   remeda@2.33.4:
     resolution: {integrity: sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
 
   retext-latin@4.0.0:
     resolution: {integrity: sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==}
@@ -4369,6 +4701,10 @@ packages:
 
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
   reusify@1.1.0:
@@ -4406,6 +4742,9 @@ packages:
 
   search-insights@2.17.3:
     resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
+
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
@@ -4461,6 +4800,10 @@ packages:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
 
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
   smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
@@ -4490,12 +4833,19 @@ packages:
     resolution: {integrity: sha512-S6ji+flMEga+1QU79NDbwZ8Ivf0S/MpupQQiIC0rTpU/ZTKgcajijJJb1OcByBQDjrXCN1/DJtGz4ZJeBMPGJw==}
     hasBin: true
 
+  split-ca@1.0.1:
+    resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   sqlstring@2.3.3:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
     engines: {node: '>= 0.6'}
+
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -4506,6 +4856,17 @@ packages:
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
@@ -4515,6 +4876,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -4577,9 +4942,21 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   thingies@2.5.0:
     resolution: {integrity: sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==}
@@ -4647,6 +5024,9 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
   twoslash-protocol@0.3.6:
     resolution: {integrity: sha512-FHGsJ9Q+EsNr5bEbgG3hnbkvEBdW5STgPU824AHUjB4kw0Dn4p8tABT7Ncg1Ie6V0+mDg3Qpy41VafZXcQhWMA==}
 
@@ -4669,6 +5049,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -4729,6 +5113,11 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -4878,8 +5267,28 @@ packages:
   wicked-good-xpath@1.3.0:
     resolution: {integrity: sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xdg-app-paths@5.1.0:
+    resolution: {integrity: sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==}
+    engines: {node: '>=6'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
 
   yaml@2.8.2:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
@@ -4891,8 +5300,23 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
+
   zeptomatch@2.1.0:
     resolution: {integrity: sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==}
+
+  zod@3.24.4:
+    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -4923,6 +5347,19 @@ packages:
 
 snapshots:
 
+  '@ai-sdk/anthropic@1.2.12(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/gateway@2.0.25(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
+      '@vercel/oidc': 3.0.5
+      zod: 3.25.76
+
   '@ai-sdk/gateway@2.0.25(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
@@ -4943,6 +5380,20 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.19(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@3.0.20(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
+
   '@ai-sdk/provider-utils@3.0.20(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
@@ -4956,6 +5407,10 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 3.25.76
+
+  '@ai-sdk/provider@1.1.3':
+    dependencies:
+      json-schema: 0.4.0
 
   '@ai-sdk/provider@2.0.1':
     dependencies:
@@ -5100,6 +5555,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@balena/dockerignore@1.0.2': {}
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -5812,6 +6269,25 @@ snapshots:
       '@repeaterjs/repeater': 3.0.6
       tslib: 2.8.1
 
+  '@grpc/grpc-js@1.14.4':
+    dependencies:
+      '@grpc/proto-loader': 0.8.1
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.0
+      yargs: 17.7.2
+
+  '@grpc/proto-loader@0.8.1':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.0
+      yargs: 17.7.2
+
   '@headlessui/react@2.2.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@floating-ui/react': 0.26.28(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -5944,6 +6420,8 @@ snapshots:
     dependencies:
       '@isaacs/balanced-match': 4.0.1
 
+  '@isaacs/cliui@9.0.0': {}
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -5952,6 +6430,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@js-sdsl/ordered-map@4.4.2': {}
 
   '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
     dependencies:
@@ -6460,6 +6940,28 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
+
   '@react-aria/focus@3.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@react-aria/interactions': 3.26.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -6849,9 +7351,49 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vercel/agent-eval@0.14.1':
+    dependencies:
+      '@ai-sdk/anthropic': 1.2.12(zod@3.25.76)
+      '@vercel/sandbox': 1.10.2
+      ai: 5.0.119(zod@3.25.76)
+      chalk: 5.6.2
+      commander: 12.1.0
+      dockerode: 4.0.12
+      dotenv: 16.6.1
+      glob: 11.1.0
+      jiti: 2.7.0
+      log-update: 6.1.0
+      minimatch: 10.2.5
+      p-limit: 6.2.0
+      tar-stream: 3.2.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
   '@vercel/oidc@3.0.5': {}
 
   '@vercel/oidc@3.1.0': {}
+
+  '@vercel/oidc@3.2.0': {}
+
+  '@vercel/sandbox@1.10.2':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      '@workflow/serde': 4.1.0-beta.2
+      async-retry: 1.3.3
+      jsonlines: 0.1.1
+      ms: 2.1.3
+      picocolors: 1.1.1
+      tar-stream: 3.1.7
+      undici: 7.25.0
+      xdg-app-paths: 5.1.0
+      zod: 3.24.4
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   '@vitest/coverage-v8@4.1.6(vitest@4.1.6)':
     dependencies:
@@ -6941,6 +7483,8 @@ snapshots:
       '@whatwg-node/promise-helpers': 1.3.2
       tslib: 2.8.1
 
+  '@workflow/serde@4.1.0-beta.2': {}
+
   '@xmldom/xmldom@0.9.8': {}
 
   acorn-jsx@5.3.2(acorn@8.15.0):
@@ -6948,6 +7492,14 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  ai@5.0.119(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 2.0.25(zod@3.25.76)
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.76
 
   ai@5.0.119(zod@4.3.4):
     dependencies:
@@ -6984,7 +7536,19 @@ snapshots:
 
   ansi-colors@4.1.3: {}
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   arg@5.0.2: {}
 
@@ -6998,6 +7562,10 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   ast-v8-to-istanbul@1.0.0:
@@ -7008,13 +7576,57 @@ snapshots:
 
   astring@1.9.0: {}
 
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+
   aws-ssl-profiles@1.1.2: {}
 
+  b4a@1.8.1: {}
+
   bail@2.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  bare-events@2.8.3: {}
+
+  bare-fs@4.7.1:
+    dependencies:
+      bare-events: 2.8.3
+      bare-path: 3.0.0
+      bare-stream: 2.13.1(bare-events@2.8.3)
+      bare-url: 2.4.3
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.9.1: {}
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.9.1
+
+  bare-stream@2.13.1(bare-events@2.8.3):
+    dependencies:
+      streamx: 2.25.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.3
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.3:
+    dependencies:
+      bare-path: 3.0.0
 
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.10: {}
+
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -7040,6 +7652,10 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
+
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -7050,6 +7666,9 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  buildcheck@0.0.7:
+    optional: true
 
   c12@3.1.0:
     dependencies:
@@ -7119,6 +7738,10 @@ snapshots:
 
   citty@0.2.0: {}
 
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
   client-only@0.0.1: {}
 
   clipboardy@4.0.0:
@@ -7127,13 +7750,27 @@ snapshots:
       is-wsl: 3.1.0
       is64bit: 2.0.0
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   clsx@2.1.1: {}
 
   code-block-writer@13.0.3: {}
 
   collapse-white-space@2.1.0: {}
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   comma-separated-tokens@2.0.3: {}
+
+  commander@12.1.0: {}
 
   commander@13.1.0: {}
 
@@ -7158,6 +7795,12 @@ snapshots:
   cose-base@2.2.0:
     dependencies:
       layout-base: 2.0.1
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.27.0
+    optional: true
 
   cross-inspect@1.0.1:
     dependencies:
@@ -7399,6 +8042,27 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  docker-modem@5.0.7:
+    dependencies:
+      debug: 4.4.3
+      readable-stream: 3.6.2
+      split-ca: 1.0.1
+      ssh2: 1.17.0
+    transitivePeerDependencies:
+      - supports-color
+
+  dockerode@4.0.12:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@grpc/grpc-js': 1.14.4
+      '@grpc/proto-loader': 0.7.15
+      docker-modem: 5.0.7
+      protobufjs: 7.6.0
+      tar-fs: 2.1.4
+      uuid: 10.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   dompurify@3.3.1:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -7432,6 +8096,10 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
+  emoji-regex@10.6.0: {}
+
+  emoji-regex@8.0.0: {}
+
   empathic@2.0.0: {}
 
   end-of-stream@1.4.5:
@@ -7444,6 +8112,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   entities@6.0.1: {}
+
+  environment@1.1.0: {}
 
   es-module-lexer@2.0.0: {}
 
@@ -7580,6 +8250,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
 
+  escalade@3.2.0: {}
+
   escape-string-regexp@5.0.0: {}
 
   esm@3.2.25: {}
@@ -7625,6 +8297,12 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   eventsource-parser@3.0.6: {}
 
   execa@8.0.1:
@@ -7652,6 +8330,8 @@ snapshots:
   fast-check@3.23.2:
     dependencies:
       pure-rand: 6.1.0
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -7720,6 +8400,10 @@ snapshots:
     dependencies:
       is-property: 1.0.2
 
+  get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.6.0: {}
+
   get-port-please@3.2.0: {}
 
   get-stream@8.0.1: {}
@@ -7748,6 +8432,15 @@ snapshots:
   glob-to-regex.js@1.2.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
+
+  glob@11.1.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.2.3
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.2
 
   globby@11.1.0:
     dependencies:
@@ -7989,6 +8682,12 @@ snapshots:
 
   is-extglob@2.1.1: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
@@ -8036,6 +8735,10 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
+
   jiti@2.6.1: {}
 
   jiti@2.7.0: {}
@@ -8056,6 +8759,8 @@ snapshots:
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsonlines@0.1.1: {}
 
   katex@0.16.27:
     dependencies:
@@ -8148,15 +8853,27 @@ snapshots:
 
   lodash-es@4.17.22: {}
 
+  lodash.camelcase@4.3.0: {}
+
   lodash.startcase@4.4.0: {}
 
   lodash@4.17.21: {}
+
+  log-update@6.1.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
 
   long@5.3.2: {}
 
   longest-streak@3.1.0: {}
 
   lru-cache@10.4.3: {}
+
+  lru-cache@11.5.0: {}
 
   lru.min@1.1.3: {}
 
@@ -8707,13 +9424,21 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
+  mimic-function@5.0.1: {}
+
   mimic-response@3.1.0: {}
 
   minimatch@10.1.1:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   mj-context-menu@0.6.1: {}
 
@@ -8745,6 +9470,9 @@ snapshots:
   named-placeholders@1.1.6:
     dependencies:
       lru.min: 1.1.3
+
+  nan@2.27.0:
+    optional: true
 
   nanoid@3.3.11: {}
 
@@ -8886,6 +9614,10 @@ snapshots:
     dependencies:
       mimic-fn: 4.0.0
 
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
   oniguruma-parser@0.12.1: {}
 
   oniguruma-to-es@4.3.4:
@@ -8893,6 +9625,8 @@ snapshots:
       oniguruma-parser: 0.12.1
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  os-paths@4.4.0: {}
 
   outdent@0.5.0: {}
 
@@ -8955,6 +9689,10 @@ snapshots:
     dependencies:
       p-try: 2.2.0
 
+  p-limit@6.2.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
@@ -8962,6 +9700,8 @@ snapshots:
   p-map@2.1.0: {}
 
   p-try@2.2.0: {}
+
+  package-json-from-dist@1.0.1: {}
 
   package-manager-detector@0.2.11:
     dependencies:
@@ -9003,6 +9743,11 @@ snapshots:
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.0
+      minipass: 7.1.3
 
   path-type@4.0.0: {}
 
@@ -9092,6 +9837,21 @@ snapshots:
       signal-exit: 3.0.7
 
   property-information@7.1.0: {}
+
+  protobufjs@7.6.0:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 24.12.4
+      long: 5.3.2
 
   pump@3.0.3:
     dependencies:
@@ -9305,9 +10065,16 @@ snapshots:
 
   remeda@2.33.4: {}
 
+  require-directory@2.1.1: {}
+
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
 
   retext-latin@4.0.0:
     dependencies:
@@ -9335,6 +10102,8 @@ snapshots:
       unified: 11.0.5
 
   retry@0.12.0: {}
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
@@ -9392,6 +10161,8 @@ snapshots:
       compute-scroll-into-view: 3.1.1
 
   search-insights@2.17.3: {}
+
+  secure-json-parse@2.7.0: {}
 
   semver@7.7.3: {}
 
@@ -9468,6 +10239,11 @@ snapshots:
 
   slash@5.1.0: {}
 
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   smol-toml@1.6.1: {}
 
   source-map-js@1.2.1: {}
@@ -9494,15 +10270,46 @@ snapshots:
       commander: 13.1.0
       wicked-good-xpath: 1.3.0
 
+  split-ca@1.0.1: {}
+
   sprintf-js@1.0.3: {}
 
   sqlstring@2.3.3: {}
+
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.27.0
 
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
 
   std-env@4.0.0: {}
+
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
 
   string_decoder@1.3.0:
     dependencies:
@@ -9516,6 +10323,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
 
@@ -9569,7 +10380,40 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.7.1
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   term-size@2.2.1: {}
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   thingies@2.5.0(tslib@2.8.1):
     dependencies:
@@ -9627,6 +10471,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  tweetnacl@0.14.5: {}
+
   twoslash-protocol@0.3.6: {}
 
   twoslash@0.3.6(typescript@5.9.3):
@@ -9644,6 +10490,8 @@ snapshots:
   unbash@3.0.0: {}
 
   undici-types@7.16.0: {}
+
+  undici@7.25.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -9731,6 +10579,8 @@ snapshots:
       react: 19.2.4
 
   util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
 
   uuid@11.1.0: {}
 
@@ -9836,16 +10686,54 @@ snapshots:
 
   wicked-good-xpath@1.3.0: {}
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2: {}
+
+  xdg-app-paths@5.1.0:
+    dependencies:
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
+  y18n@5.0.8: {}
 
   yaml@2.8.2: {}
 
   yaml@2.9.0: {}
 
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  yocto-queue@1.2.2: {}
+
   zeptomatch@2.1.0:
     dependencies:
       grammex: 3.1.12
       graphmatch: 1.1.0
+
+  zod@3.24.4: {}
 
   zod@3.25.76: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - "packages/*"
   - "examples/*"
+  - "eval"
 
 catalog:
   graphql: "16.14.0"


### PR DESCRIPTION
## Why

§9 of the TSKaigi 2026 talk needs empirical evidence on whether an AI coding
agent can write idiomatic gqlkit (and naturally avoid N+1 / hide sensitive
fields) without explicit hints in the prompt — and how much the bundled
`gqlkit-guide` skill helps once it ships.

This PR builds the harness that produces that evidence and captures one
40-run pass against `claude-sonnet-4-6`.

## Summary

New `@gqlkit-ts/eval` workspace package wrapping [`@vercel/agent-eval`]:

- 8 evals: `{01-crud, 02-relation}` × `{codegen, Pothos, gqlkit-plain, gqlkit-skill}`.
- PROMPTs deliberately omit hints about `mappers` / `objectRef` / DataLoader / N+1.
  EVAL.ts checks those properties anyway by inspecting the agent's output.
- `shared/` holds the source-of-truth backing types + DataLoader stubs;
  `sync-fixtures.ts` mirrors them into every eval and copies the
  `gqlkit-guide` skill (the output of `pnpm gqlkit docs`) into the
  `*-gqlkit-skill` variants.
- `experiments/sonnet.ts` targets `claude-code × claude-sonnet-4-6`.
- `scripts/summarize.ts` walks `results/` and emits a markdown report.
- `REPORT.md` captures the latest 40-run result.

Initial findings (see `REPORT.md` for the full breakdown):

| | gqlkit-plain | gqlkit-skill | delta |
|---|---:|---:|---:|
| 01-crud mean turns | 11.0 | 7.8 | -29% |
| 01-crud mean duration | 592s | 345s | -42% |
| 02-relation mean turns | 11.2 | 7.8 | -30% |
| 02-relation mean duration | 466s | 387s | -17% |

DataLoader / `User.email`-exclusion assertions pass in **every** run across
all 40, with no prompt-side hints.

## Notes for reviewers

- `eval/` is added as a new workspace package (`@gqlkit-ts/eval`) via
  `pnpm-workspace.yaml`. It is `private: true` and not part of the public
  surface.
- `biome.jsonc`: `**/testdata` and `**/*.md` are now excluded.
  - `testdata/` was already partially excluded (`__generated__` only). The
    new exclusion covers the rest; lint errors that surfaced under
    `packages/cli/src/gen-orchestrator/testdata/` were pre-existing and
    unrelated to this PR.
  - `*.md` exclusion was needed because Biome 2.4 reports an "unsupported
    feature" for Markdown, and this PR adds many `.md` files from the
    bundled `gqlkit-guide` skill snapshot.
- `packages/cli/src/shared/{directive-definition-extractor,directive-detector,interface-validator}.ts`:
  biome `--unsafe` auto-fix applied `useOptionalChain` (3 small rewrites).
  Functionally equivalent.
- `examples/with-ai-sdk/src/scenario.test.ts`: one `// biome-ignore` line for
  `noExplicitAny` on a `LanguageModelV3` mock that needs `any[]` to bypass
  strict stream-part typing.
- `eval/shared/skill/.claude/skills/gqlkit-guide/references` is committed as
  a symlink pointing into `packages/cli/docs/` (matches what
  `gqlkit docs --claude` emits). The sandbox-side copies are materialized as
  real directories via `sync-fixtures.ts`, so this only matters on the host.

## How it ran

```bash
cd eval
cp .env.example .env  # ANTHROPIC_API_KEY + DOCKER_HOST for Colima
pnpm sync             # distribute shared fixtures + skill into each eval
for i in 1 2 3 4 5; do pnpm sonnet --force; done   # 5 × 8 = 40 runs
pnpm tsx scripts/summarize.ts 5                    # regenerate REPORT.md
```